### PR TITLE
Remove the alpha prerelease tag due to match published pkg.

### DIFF
--- a/wavelink/__init__.py
+++ b/wavelink/__init__.py
@@ -2,7 +2,7 @@ __title__ = 'WaveLink'
 __author__ = 'EvieePy'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2019 (c) EvieePy'
-__version__ = '0.2.09a'
+__version__ = '0.2.09'
 
 from .client import Client
 from .errors import *


### PR DESCRIPTION
As this package is released on PyPI already as full versions, not alpha pre-releases, there's no reason to continue keeping this version tag in the `__init__.py`, so this PR removes it.