### PR TITLE
Design changes to client.get_player

### DIFF
--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -176,26 +176,29 @@ class Client:
 
         return sorted(nodes, key=lambda n: len(n.players))[0]
 
-    def get_player(self, guild_id: int, cls=None) -> Optional[Player]:
+    def get_player(self, guild_id: int, *, cls=None, node_id=None) -> Player:
         """Retrieve a player for the given guild ID. If None, a player will be created and returned.
 
         Parameters
         ------------
-        guild_id:
+        guild_id: int
             The guild ID to retrieve a player for.
-        Optional[cls: class]
+        cls: Optional[class]
             An optional class to pass to build from, overriding the default :class:`Player` class.
             This must be similar to :class:`Player`. E.g a subclass.
+        node_id: Optional[str]
+            An optional Node identifier to create a player under. If the player already exists this will be ignored.
+            Otherwise an attempt to find the node and assign a new player will be made.
 
         Returns
         ---------
-        Optional[:class:`wavelink.player.Player`]
+        Player
             The :class:`wavelink.player.Player` associated with the given guild ID.
 
         Raises
         --------
         InvalidIDProvided
-            The given ID does not yield a valid guild.
+            The given ID does not yield a valid guild or Node.
         ZeroConnectedNodes
             There are no :class:`wavelink.node.Node`'s currently connected.
         """
@@ -217,6 +220,17 @@ class Client:
 
         if not cls:
             cls = Player
+
+        if node_id:
+            node = self.get_node(identifier=node_id)
+
+            if not node:
+                raise InvalidIDProvided(f'A Node with the identifier <{node_id}> does not exist.')
+
+            player = cls(self.bot, guild_id, node)
+            node.players[guild_id] = player
+
+            return player
 
         shard_options = []
         region_options = []

--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -201,6 +201,9 @@ class Client:
             The given ID does not yield a valid guild or Node.
         ZeroConnectedNodes
             There are no :class:`wavelink.node.Node`'s currently connected.
+
+        .. versionchanged:: 0.3.0
+            cls is now a keyword only argument.
         """
         players = self.players
 


### PR DESCRIPTION
Added an optional kwarg `node_id`.
Breaking change: positional arg `cls`  is now a kwarg.

`node_id` allows users to specify which node a new player should be created under. If the node cannot be found an error is raised.
Players that already exist are not affected by this kwarg.

`cls` is now a kwarg. This is a breaking change.