### PR TITLE
Update Requirements.txt for Discord.py 1.3.0a

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp>=3.3.0,<3.6.0
+aiohttp>=3.3.0,<3.7.0
 websockets>=6.0,<7.0


### PR DESCRIPTION
This is to fix issue #38 

We are currently testing this with a Discord after updating aiohttp to match Discord.py Version: 1.3.0a2146+g4ef0fb0 with no errors. 
