### PR TITLE
Make Client.get_tracks raise ZeroConnectedNodes

### DIFF
--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -94,8 +94,16 @@ class Client:
         Union[list, TrackPlaylist, None]:
             A list of or :class:`TrackPlaylist` instance of :class:`Track` objects.
             This could be None if no tracks were found.
+
+        Raises
+        --------
+        ZeroConnectedNodes
+            There are no :class:`wavelink.node.Node`s currently connected.
         """
         node = self.get_best_node()
+        
+        if node is None:
+            raise ZeroConnectedNodes
 
         return await node.get_tracks(query)
 


### PR DESCRIPTION
This pull request makes `Client.get_tracks` raise `ZeroConnectedNodes` when there are no connected nodes available. This is done to avoid an `AttributeError` which may confuse unexperienced people.

I was planning to make `Client.get_best_node` do this instead, but wasn't too sure if that's how the design was originally inteded.