### PR TITLE
Fix outdated docs example

### DIFF
--- a/docs/wavelink.rst
+++ b/docs/wavelink.rst
@@ -48,7 +48,7 @@ A quick and easy bot example:
             print(f'Logged in as {self.user.name} | {self.user.id}')
 
 
-    class Music:
+    class Music(commands.Cog):
 
         def __init__(self, bot):
             self.bot = bot


### PR DESCRIPTION
This pull request fixes the example present in the docs by making the ``Music`` cog actually subclass ``commands.Cog`` as it's required by the current stable version of discord.py.