### PR TITLE
Add Optional argument 'heartbeat' to node and initiate_node.

### DIFF
--- a/wavelink/__init__.py
+++ b/wavelink/__init__.py
@@ -2,7 +2,7 @@ __title__ = 'WaveLink'
 __author__ = 'EvieePy'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2019-2020 (c) PythonistaGuild'
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 from .client import Client
 from .errors import *

--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -361,7 +361,7 @@ class Client:
         return player
 
     async def initiate_node(self, host: str, port: int, *, rest_uri: str, password: str, region: str, identifier: str,
-                            shard_id: int = None, secure: bool = False) -> Node:
+                            shard_id: int = None, secure: bool = False, heartbeat: float = None) -> Node:
         """|coro|
 
         Initiate a Node and connect to the provided server.
@@ -384,7 +384,9 @@ class Client:
             An optional Shard ID to associate with the :class:`wavelink.node.Node`. Could be None.
         secure: bool
             Whether the websocket should be started with the secure wss protocol.
-
+        heartbeat: Optional[float]
+            Send ping message every heartbeat seconds and wait pong response, if pong response is not received then close connection.
+        
         Returns
         ---------
         :class:`wavelink.node.Node`
@@ -409,8 +411,9 @@ class Client:
                     shard_id=shard_id,
                     session=self.session,
                     client=self,
-                    secure=secure)
-
+                    secure=secure,
+                    heartbeat=heartbeat)
+        
         await node.connect(bot=self.bot)
 
         node.available = True

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -67,6 +67,7 @@ class Node:
                  identifier: str,
                  shard_id: int = None,
                  secure: bool = False,
+                 heartbeat: float = None
                  ):
 
         self.host = host
@@ -78,6 +79,7 @@ class Node:
         self.region = region
         self.identifier = identifier
         self.secure = secure
+        self.heartbeat = heartbeat
 
         self.shard_id = shard_id
 

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -72,7 +72,7 @@ class WebSocket:
                 uri = f'ws://{self.host}:{self.port}'
 
             if not self.is_connected:
-                self._websocket = await self._node.session.ws_connect(uri, headers=self.headers)
+                self._websocket = await self._node.session.ws_connect(uri, headers=self.headers, heartbeat=self._node.heartbeat)
 
         except Exception as error:
             self._last_exc = error


### PR DESCRIPTION
## Why?
This stabilizes connection to Nodes hosted on a VPS with a router or any such intermediate process that closes the connection if it remains idle.
Which puts the bot in a "reconnection" loop, this PR fixes that.
#### Example
```py
 async def start_nodes(self) -> None:
        """Connect and intiate nodes."""
        nodes = {'MAIN': {'host': 'lavaserver.badhost.com',
                          'port': 80,
                          'rest_uri': 'http://lavaserver.badhost.com',
                          'password': "verytrivialpassword",
                          'identifier': 'MAIN',
                          'region': 'us_central',
                          'heartbeat': 40.0 # ping the server every 40s 
                          }}                # to prevent router from terminating connection

        for n in nodes.values():
            await self.bot.wavelink.initiate_node(**n)
```

The change introduced is not breaking since heartbeat parameter is Optional[].
The Docstring for `initiate_node` method has been updated.