### PR TITLE
Use hqdefault instead of maxresdefault

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -96,7 +96,7 @@ class Track:
         self.dead = False
 
         if self.ytid:
-            self.thumb = f"https://img.youtube.com/vi/{self.ytid}/maxresdefault.jpg"
+            self.thumb = f"https://img.youtube.com/vi/{self.ytid}/hqdefault.jpg"
         else:
             self.thumb = None
 


### PR DESCRIPTION
[According to youtube API doc](https://developers.google.com/youtube/v3/docs/thumbnails#properties) not all video have a maxres version of their thumbnail.

Example:
https://img.youtube.com/vi/cwQgjq0mCdE/hqdefault.jpg Work but not 
https://img.youtube.com/vi/cwQgjq0mCdE/maxresdefault.jpg