### PR TITLE
Added two events, WebsocketConnectionFailedEvent and WebsocketConnectionClosedEvent

### DIFF
--- a/wavelink/events.py
+++ b/wavelink/events.py
@@ -26,8 +26,8 @@ __all__ = ('TrackEnd',
            'TrackStuck',
            'TrackStart',
            'WebsocketClosed',
-           'WebsocketConnectionFailed',
-           'WebsocketConnectionClosed')
+           'NodeConnectionFailed',
+           'NodeConnectionClosed')
 
 
 class TrackEnd:
@@ -150,7 +150,7 @@ class WebsocketClosed:
         return 'WebsocketClosedEvent'
 
 
-class WebsocketConnectionFailed:
+class NodeConnectionFailed:
     """Event dispatched when the connection to a node failed.
     Attributes
     ------------
@@ -167,7 +167,7 @@ class WebsocketConnectionFailed:
         return 'WebsocketConnectionFailedEvent'
 
 
-class WebsocketConnectionClosed:
+class NodeConnectionClosed:
     """Event dispatched when the connection to a node has been closed.
     Attributes
     ------------

--- a/wavelink/events.py
+++ b/wavelink/events.py
@@ -164,7 +164,7 @@ class NodeConnectionFailed:
         self.node = data.get('node')
 
     def __str__(self):
-        return 'WebsocketConnectionFailedEvent'
+        return 'NodeConnectionFailed'
 
 
 class NodeConnectionClosed:
@@ -181,4 +181,4 @@ class NodeConnectionClosed:
         self.node = data.get('node')
 
     def __str__(self):
-        return 'WebsocketConnectionClosedEvent'
+        return 'NodeConnectionClosed'

--- a/wavelink/events.py
+++ b/wavelink/events.py
@@ -25,7 +25,9 @@ __all__ = ('TrackEnd',
            'TrackException',
            'TrackStuck',
            'TrackStart',
-           'WebsocketClosed')
+           'WebsocketClosed',
+           'WebsocketConnectionFailed',
+           'WebsocketConnectionClosed')
 
 
 class TrackEnd:
@@ -146,3 +148,37 @@ class WebsocketClosed:
 
     def __str__(self):
         return 'WebsocketClosedEvent'
+
+
+class WebsocketConnectionFailed:
+    """Event dispatched when the connection to a node failed.
+    Attributes
+    ------------
+    node: :class:`wavelink.node.Node`
+        The node associated with the event.
+    """
+
+    __slots__ = 'node'
+
+    def __init__(self, data: dict):
+        self.node = data.get('node')
+
+    def __str__(self):
+        return 'WebsocketConnectionFailedEvent'
+
+
+class WebsocketConnectionClosed:
+    """Event dispatched when the connection to a node has been closed.
+    Attributes
+    ------------
+    node: :class:`wavelink.node.Node`
+        The node associated with the event.
+    """
+
+    __slots__ = 'node'
+
+    def __init__(self, data: dict):
+        self.node = data.get('node')
+
+    def __str__(self):
+        return 'WebsocketConnectionClosedEvent'

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -83,6 +83,9 @@ class WebSocket:
             else:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+                if self._node.hook is not None:
+                    self.bot.loop.create_task(self._node.hook(WebsocketConnectionFailed({"node": self._node})))
+
             return
 
         if not self._task:
@@ -107,7 +110,8 @@ class WebSocket:
 
                 self._closed = True
                 retry = backoff.delay()
-
+                if self._node.hook is not None:
+                    self.bot.loop.create_task(self._node.hook(WebsocketConnectionClosed({"node": self._node})))
                 __log__.warning(f'\nWEBSOCKET | Connection closed:: Retrying connection in <{retry}> seconds\n')
 
                 await asyncio.sleep(retry)

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -84,7 +84,7 @@ class WebSocket:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
                 if self._node.hook is not None:
-                    self.bot.loop.create_task(self._node.hook(WebsocketConnectionFailed({"node": self._node})))
+                    self.bot.loop.create_task(self._node.hook(NodeConnectionFailed({"node": self._node})))
 
             return
 
@@ -111,7 +111,7 @@ class WebSocket:
                 self._closed = True
                 retry = backoff.delay()
                 if self._node.hook is not None:
-                    self.bot.loop.create_task(self._node.hook(WebsocketConnectionClosed({"node": self._node})))
+                    self.bot.loop.create_task(self._node.hook(NodeConnectionClosed({"node": self._node})))
                 __log__.warning(f'\nWEBSOCKET | Connection closed:: Retrying connection in <{retry}> seconds\n')
 
                 await asyncio.sleep(retry)


### PR DESCRIPTION
`WebsocketConnectionFailedEvent` gets called when Wavelink can't connect to a node.

`WebsocketConnectionClosedEvent` gets called when the connection to a node has been closed (for example if the Lavalink server has been shut down).