### PR TITLE
fix for d.py 1.4.0a

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -241,10 +241,14 @@ class Player:
 
     def _get_shard_socket(self, shard_id: int) -> Optional[DiscordWebSocket]:
         if isinstance(self.bot, commands.AutoShardedBot):
-            return self.bot.shards[shard_id].ws
+            if hasattr(self.bot.shards[shard_id],"ws"):
+                return self.bot.shards[shard_id].ws
+            else:
+                return self.bot.shards[shard_id]._parent.ws
 
         if self.bot.shard_id is None or self.bot.shard_id == shard_id:
             return self.bot.ws
+
 
     async def connect(self, channel_id: int):
         """|coro|

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -241,9 +241,9 @@ class Player:
 
     def _get_shard_socket(self, shard_id: int) -> Optional[DiscordWebSocket]:
         if isinstance(self.bot, commands.AutoShardedBot):
-            if hasattr(self.bot.shards[shard_id],"ws"):
+            try:
                 return self.bot.shards[shard_id].ws
-            else:
+            except AttributeError:
                 return self.bot.shards[shard_id]._parent.ws
 
         if self.bot.shard_id is None or self.bot.shard_id == shard_id:


### PR DESCRIPTION
Quick fix for the 'ShardInfo' object has no attribute 'ws' error when using discord.py 1.4.0a