### PR TITLE
Add /decodetracks endpoint support

### DIFF
--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -25,10 +25,10 @@ import asyncio
 import logging
 from discord.ext import commands
 from functools import partial
-from typing import Optional, Union
+from typing import Optional, Union, List, Iterable
 
 from .errors import *
-from .player import Player
+from .player import Player, Track
 from .node import Node
 
 
@@ -153,13 +153,13 @@ class Client:
             There are no :class:`wavelink.node.Node`s currently connected.
         """
         node = self.get_best_node()
-        
+
         if node is None:
             raise ZeroConnectedNodes
 
         return await node.get_tracks(query)
 
-    async def build_track(self, identifier: str):
+    async def build_track(self, identifier: str) -> Track:
         """|coro|
 
         Build a track object with a valid track identifier.
@@ -187,6 +187,35 @@ class Client:
             raise ZeroConnectedNodes
 
         return await node.build_track(identifier)
+
+    async def build_tracks(self, identifiers: Iterable[str]) -> List[Tracks]:
+        """|coro|
+
+        Build multiple track objects with a valid track identifier.
+
+        Parameters
+        ------------
+        identifiers: List[str]
+            The track unique Base64 encoded identifiers. This is usually retrieved from various lavalink events.
+
+        Returns
+        ---------
+        List[:class:`wavelink.player.Track`]
+            The tracks built from the Base64 identifiers.
+
+        Raises
+        --------
+        ZeroConnectedNodes
+            There are no :class:`wavelink.node.Node`s currently connected.
+        BuildTrackError
+            Decoding and building one of the tracks failed.
+        """
+        node = self.get_best_node()
+
+        if node is None:
+            raise ZeroConnectedNodes
+
+        return await node.build_tracks(identifiers)
 
     def _get_players(self) -> dict:
         players = []
@@ -386,7 +415,7 @@ class Client:
             Whether the websocket should be started with the secure wss protocol.
         heartbeat: Optional[float]
             Send ping message every heartbeat seconds and wait pong response, if pong response is not received then close connection.
-        
+
         Returns
         ---------
         :class:`wavelink.node.Node`
@@ -413,7 +442,7 @@ class Client:
                     client=self,
                     secure=secure,
                     heartbeat=heartbeat)
-        
+
         await node.connect(bot=self.bot)
 
         node.available = True

--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -159,43 +159,14 @@ class Client:
 
         return await node.get_tracks(query)
 
-    async def build_track(self, identifier: str) -> Track:
-        """|coro|
-
-        Build a track object with a valid track identifier.
-
-        Parameters
-        ------------
-        identifier: str
-            The tracks unique Base64 encoded identifier. This is usually retrieved from various lavalink events.
-
-        Returns
-        ---------
-        :class:`wavelink.player.Track`
-            The track built from a Base64 identifier.
-
-        Raises
-        --------
-        ZeroConnectedNodes
-            There are no :class:`wavelink.node.Node`s currently connected.
-        BuildTrackError
-            Decoding and building the track failed.
-        """
-        node = self.get_best_node()
-
-        if node is None:
-            raise ZeroConnectedNodes
-
-        return await node.build_track(identifier)
-
-    async def build_tracks(self, identifiers: Iterable[str]) -> List[Tracks]:
+    async def build_tracks(self, *identifiers: str) -> List[Track]:
         """|coro|
 
         Build multiple track objects with a valid track identifier.
 
         Parameters
         ------------
-        identifiers: List[str]
+        identifiers: str
             The track unique Base64 encoded identifiers. This is usually retrieved from various lavalink events.
 
         Returns
@@ -215,7 +186,7 @@ class Client:
         if node is None:
             raise ZeroConnectedNodes
 
-        return await node.build_tracks(identifiers)
+        return await node.build_tracks(*identifiers)
 
     def _get_players(self) -> dict:
         players = []

--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -25,7 +25,7 @@ import asyncio
 import logging
 from discord.ext import commands
 from functools import partial
-from typing import Optional, Union, List, Iterable
+from typing import Optional, Union, List
 
 from .errors import *
 from .player import Player, Track
@@ -162,7 +162,7 @@ class Client:
     async def build_tracks(self, *identifiers: str) -> List[Track]:
         """|coro|
 
-        Build multiple track objects with a valid track identifier.
+        Build track objects with valid track identifier(s).
 
         Parameters
         ------------

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -23,7 +23,7 @@ SOFTWARE.
 import inspect
 import logging
 from discord.ext import commands
-from typing import Optional, Union, Iterable, List
+from typing import Optional, Union, List
 from urllib.parse import quote
 
 from .errors import *
@@ -169,7 +169,7 @@ class Node:
     async def build_tracks(self, *identifiers: str) -> List[Track]:
         """|coro|
 
-        Build multiple track objects with valid track identifiers.
+        Build track objects with valid track identifier(s).
 
         Parameters
         ------------

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -166,46 +166,14 @@ class Node:
 
             return tracks
 
-    async def build_track(self, identifier: str) -> Track:
-        """|coro|
-
-        Build a track object with a valid track identifier.
-
-        Parameters
-        ------------
-        identifier: str
-            The tracks unique Base64 encoded identifier. This is usually retrieved from various lavalink events.
-
-        Returns
-        ---------
-        :class:`wavelink.player.Track`
-            The track built from a Base64 identifier.
-
-        Raises
-        --------
-        BuildTrackError
-            Decoding and building the track failed.
-        """
-        async with self.session.get(f'{self.rest_uri}/decodetrack?',
-                                    headers={'Authorization': self.password},
-                                    params={'track': identifier}) as resp:
-            data = await resp.json()
-
-            if not resp.status == 200:
-                raise BuildTrackError(f'Failed to build track. Status: {data["status"]}, Error: {data["error"]}.'
-                                      f'Check the identfier is correct and try again.')
-
-            track = Track(id_=identifier, info=data)
-            return track
-
-    async def build_tracks(self, identifiers: Iterable[str]) -> List[Track]:
+    async def build_tracks(self, *identifiers: str) -> List[Track]:
         """|coro|
 
         Build multiple track objects with valid track identifiers.
 
         Parameters
         ------------
-        identifiers: List[str]
+        identifiers: str
             The track unique Base64 encoded identifiers. This is usually retrieved from various lavalink events.
 
         Returns


### PR DESCRIPTION
In addition to the `Client/Node.build_track` method, this adds the corresponding POST to `/decodetracks` to batch decode track identifiers. Useful if there are a large number of tracks that need to be decoded.

The definition of the endpoint can be found here: https://github.com/Frederikam/Lavalink/blob/18ee6778674b7f9a817893b676a91a9b96e642f3/LavalinkServer/src/main/java/lavalink/server/player/AudioLoaderRestHandler.java#L140