### PR TITLE
Support custom JSON encoders

### DIFF
--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -25,6 +25,7 @@ import asyncio
 import logging
 from discord.ext import commands
 from functools import partial
+from json import dumps
 from typing import Optional, Union
 
 from .errors import *
@@ -68,6 +69,8 @@ class Client:
         self.session = aiohttp.ClientSession(loop=self.loop)
 
         self.nodes = {}
+
+        self._dumps = dumps
 
         bot.add_listener(self.update_handler, 'on_socket_response')
 
@@ -153,7 +156,7 @@ class Client:
             There are no :class:`wavelink.node.Node`s currently connected.
         """
         node = self.get_best_node()
-        
+
         if node is None:
             raise ZeroConnectedNodes
 
@@ -386,7 +389,7 @@ class Client:
             Whether the websocket should be started with the secure wss protocol.
         heartbeat: Optional[float]
             Send ping message every heartbeat seconds and wait pong response, if pong response is not received then close connection.
-        
+
         Returns
         ---------
         :class:`wavelink.node.Node`
@@ -412,8 +415,9 @@ class Client:
                     session=self.session,
                     client=self,
                     secure=secure,
-                    heartbeat=heartbeat)
-        
+                    heartbeat=heartbeat,
+                    dumps=self._dumps)
+
         await node.connect(bot=self.bot)
 
         node.available = True
@@ -467,3 +471,18 @@ class Client:
                 pass
             else:
                 await player._voice_state_update(data['d'])
+
+    def set_serializer(self, serializer_function) -> None:
+        """Sets the JSON dumps function for use in the websocket.
+        The default one is the built-in JSON module.
+
+        Parameters
+        ----------
+        serializer_function: Callable[[Dict[str, Any]]], Union[str, bytes]]
+            The function that serializes the JSON data to a string or bytes.
+        """
+        self._dumps = serializer_function
+        # Update all existing nodes
+        for node in self.nodes.values():
+            node._dumps = serializer_function
+            node._websocket._dumps = serializer_function

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -21,9 +21,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 import inspect
+import json
 import logging
 from discord.ext import commands
-from typing import Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from urllib.parse import quote
 
 from .errors import *
@@ -67,7 +68,8 @@ class Node:
                  identifier: str,
                  shard_id: int = None,
                  secure: bool = False,
-                 heartbeat: float = None
+                 heartbeat: float = None,
+                 dumps: Callable[[Dict[str, Any]], Union[str, bytes]] = json.dumps
                  ):
 
         self.host = host
@@ -80,6 +82,8 @@ class Node:
         self.identifier = identifier
         self.secure = secure
         self.heartbeat = heartbeat
+
+        self._dumps = dumps
 
         self.shard_id = shard_id
 
@@ -125,7 +129,8 @@ class Node:
                                     password=self.password,
                                     shard_count=self.shards,
                                     user_id=self.uid,
-                                    secure=self.secure)
+                                    secure=self.secure,
+                                    dumps=self._dumps)
         await self._websocket._connect()
 
         __log__.info(f'NODE | {self.identifier} connected:: {self.__repr__()}')

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -47,6 +47,7 @@ class WebSocket:
         self.shard_count = attrs.get('shard_count')
         self.user_id = attrs.get('user_id')
         self.secure = attrs.get('secure')
+        self._dumps = attrs.get('dumps')
 
         self._websocket = None
         self._last_exc = None
@@ -165,4 +166,12 @@ class WebSocket:
     async def _send(self, **data):
         if self.is_connected:
             __log__.debug(f'WEBSOCKET | Sending Payload:: {data}')
-            await self._websocket.send_json(data)
+            data_str = self._dumps(data)
+            if isinstance(data_str, bytes):
+                # Some JSON libraries serialize to bytes
+                # Yet Lavalink does not support binary websockets
+                # So we need to decode. In the future, maybe
+                # self._websocket.send_bytes could be used
+                # if Lavalink ever implements it
+                data_str = data_str.decode('utf-8')
+            await self._websocket.send_str(data_str)


### PR DESCRIPTION
This adds support to do things like `bot.wavelink.set_serializer(ujson.dumps)` and pretty much any other JSON encoder that dumps to strings or bytes. I did not know a better way to do this other than 3 attributes on all classes to make sure they are being created correctly for any future cases.

I left a note regarding sending bytes, as it would be technically more efficient, yet Lavalink rejects binary traffic for now. Might want to request that in upstream.

I've tested the basic idea of dumping and then using `send_str` in production with orjson and the `send_json` from aiohttp pretty much dumps it and sends it then anyways, so there is no overhead created here, yet using a kwarg to the `send_json` would not allow JSON encoders that return bytes, so I decided for this way.