### PR TITLE
Add support for resuming sessions

### DIFF
--- a/wavelink/errors.py
+++ b/wavelink/errors.py
@@ -44,3 +44,6 @@ class AuthorizationFailure(WavelinkException):
 
 class BuildTrackError(WavelinkException):
     """Exception raised when a track is failed to be decoded and re-built."""
+
+class NodeSessionClosedError(WavelinkException):
+    """Exception raised when a Node's session can't be or is not resumed."""

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -64,15 +64,6 @@ class Node:
         The shard id, defuault value is None.
     heartbeat: float
         Duration between pings, helps keep WS stable. Defaults to None to disable.
-    resume_session: bool
-            If True then Lavalink server will continue to play music until bot reconnects or
-            till `resume_timeout` and then shuts-down all Players. Defaults to False.
-    resume_timeout: float
-        Has no effect unless resume_session is True.
-    resume_key: str
-        Has no effect unless resume_session is True. Defaults to a secret AlphaNumeric key that is 32 characters long
-    payload_timeout: float
-        Has no effect unless resume_session is True. Amount of time a send request should be queued.
     players: Dict[int, Player]
         A dictionary with guild id as key and the respective guild's Player as value. Please use :func:`Node.get_player` instead.
     session: aiohttp.ClientSession
@@ -115,10 +106,10 @@ class Node:
         self.identifier = identifier
         self.secure = secure
         self.heartbeat = heartbeat
-        self.resume_session = resume_session
-        self.resume_timeout = resume_timeout
-        self.resume_key = resume_key
-        self.payload_timeout = payload_timeout
+        self._resume_session = resume_session
+        self._resume_timeout = resume_timeout
+        self._resume_key = resume_key
+        self._payload_timeout = payload_timeout
         self.shard_id = shard_id
 
         self.players = {}
@@ -164,11 +155,12 @@ class Node:
                                     shard_count=self.shards,
                                     user_id=self.uid,
                                     secure=self.secure,
-                                    resume_session=self.resume_session,
-                                    resume_timeout=self.resume_timeout,
-                                    resume_key=self.resume_key,
-                                    payload_timeout=self.payload_timeout)
+                                    resume_session=self._resume_session,
+                                    resume_timeout=self._resume_timeout,
+                                    resume_key=self._resume_key,
+                                    payload_timeout=self._payload_timeout)
         await self._websocket._connect()
+        del self._resume_session, self._resume_timeout, self._resume_key, self._payload_timeout
 
         __log__.info(f'NODE | {self.identifier} connected:: {self.__repr__()}')
 

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -22,14 +22,14 @@ SOFTWARE.
 """
 import inspect
 import logging
-from discord.ext import commands
 from typing import Optional, Union
 from urllib.parse import quote
+
+from discord.ext import commands
 
 from .errors import *
 from .player import Player, Track, TrackPlaylist
 from .websocket import WebSocket
-
 
 __log__ = logging.getLogger(__name__)
 
@@ -46,12 +46,43 @@ class Node:
         The host address the node is connected to.
     port: int
         The port the node is connected to.
+    shards: int
+        The number of Shards.
     rest_uri: str
         The rest server address the node is connecte to.
+    uid: int
+        The user id.
+    password: str
+        The Node's password
     region: str
         The region provided to the node on connection.
     identifier: str
         The unique indentifier associated with the node.
+    secure: bool
+        Wether the web-sockect connection is secure.
+    shard_id: Optional[int]
+        The shard id, defuault value is None.
+    heartbeat: float
+        Duration between pings, helps keep WS stable. Defaults to None to disable.
+    resume_session: bool
+            If True then Lavalink server will continue to play music until bot reconnects or
+            till `resume_timeout` and then shuts-down all Players. Defaults to False.
+    resume_timeout: float
+        Has no effect unless resume_session is True.
+    resume_key: str
+        Has no effect unless resume_session is True. Defaults to a secret AlphaNumeric key that is 32 characters long
+    payload_timeout: float
+        Has no effect unless resume_session is True. Amount of time a send request should be queued.
+    players: Dict[int, Player]
+        A dictionary with guild id as key and the respective guild's Player as value. Please use :func:`Node.get_player` instead.
+    session: aiohttp.ClientSession
+        The aiohttp session.
+    hook: Callable
+        A callable object. use :func:`Node.set_hook`
+    available: bool
+        Wether the Node is in use or not. Use is_available instead.
+    stats: Optional[:class:`Stats`]
+        The Node's stats, sent by the server. Could be None.
     """
 
     def __init__(self, host: str,
@@ -67,7 +98,11 @@ class Node:
                  identifier: str,
                  shard_id: int = None,
                  secure: bool = False,
-                 heartbeat: float = None
+                 heartbeat: float,
+                 resume_session: bool,
+                 resume_timeout: float,
+                 resume_key: str,
+                 payload_timeout: float
                  ):
 
         self.host = host
@@ -80,7 +115,10 @@ class Node:
         self.identifier = identifier
         self.secure = secure
         self.heartbeat = heartbeat
-
+        self.resume_session = resume_session
+        self.resume_timeout = resume_timeout
+        self.resume_key = resume_key
+        self.payload_timeout = payload_timeout
         self.shard_id = shard_id
 
         self.players = {}
@@ -125,7 +163,11 @@ class Node:
                                     password=self.password,
                                     shard_count=self.shards,
                                     user_id=self.uid,
-                                    secure=self.secure)
+                                    secure=self.secure,
+                                    resume_session=self.resume_session,
+                                    resume_timeout=self.resume_timeout,
+                                    resume_key=self.resume_key,
+                                    payload_timeout=self.payload_timeout)
         await self._websocket._connect()
 
         __log__.info(f'NODE | {self.identifier} connected:: {self.__repr__()}')
@@ -252,8 +294,10 @@ class Node:
             self._websocket._task.cancel()
         except Exception:
             pass
-
+        await self._websocket.close()
+        __log__.info(f"{self} | Destroyed and disconnected")
         del self._client.nodes[self.identifier]
+        return
 
     async def _send(self, **data) -> None:
         __log__.debug(f'NODE | Sending payload:: <{data}> ({self.__repr__()})')

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -160,7 +160,7 @@ class Node:
                                     resume_key=self._resume_key,
                                     payload_timeout=self._payload_timeout)
         await self._websocket._connect()
-        del self._resume_session, self._resume_timeout, self._resume_key, self._payload_timeout
+        # del self._resume_session, self._resume_timeout, self._resume_key, self._payload_timeout
 
         __log__.info(f'NODE | {self.identifier} connected:: {self.__repr__()}')
 

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -192,6 +192,9 @@ class WebSocket:
             self._node.available = False
             if isinstance(error, aiohttp.WSServerHandshakeError) and error.status == 401:
                 __log__.critical(f'\nAuthorization Failed for Node:: {self._node}\n')
+                if self.resume_session:
+                    self.resume_key = self._gen_key() # Auth maybe due to key, so we change it immidiately
+                    self.client.loop.create_task(self._configure_resume())
             else:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -41,11 +41,11 @@ __log__ = logging.getLogger(__name__)
 
 EventMapping = MappingProxyType(
     {
-        "TrackEndEvent": ("on_track_end", TrackEnd(data)),
-        "TrackStartEvent": ("on_track_start", TrackStart(data)),
-        "TrackExceptionEvent": ("on_track_exception", TrackException(data)),
-        "TrackStuckEvent": ("on_track_stuck", TrackStuck(data)),
-        "WebSocketClosedEvent": ("on_websocket_closed", WebsocketClosed(data)),
+        "TrackEndEvent": ("on_track_end", TrackEnd),
+        "TrackStartEvent": ("on_track_start", TrackStart),
+        "TrackExceptionEvent": ("on_track_exception", TrackException),
+        "TrackStuckEvent": ("on_track_stuck", TrackStuck),
+        "WebSocketClosedEvent": ("on_websocket_closed", WebsocketClosed),
     }
 )
 
@@ -256,7 +256,8 @@ class WebSocket:
                 return
 
             try:
-                listener, payload = EventMapping[data['type']]
+                listener, payload_type = EventMapping[data['type']]
+                payload = payload_type(data)
             except KeyError:
                 __log__.exception('Unknown Event received!')
                 return

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -194,7 +194,6 @@ class WebSocket:
                 __log__.critical(f'\nAuthorization Failed for Node:: {self._node}\n')
                 if self.resume_session:
                     self.resume_key = self._gen_key() # Auth maybe due to key, so we change it immidiately
-                    self.client.loop.create_task(self._configure_resume())
             else:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -20,20 +20,75 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-import aiohttp
 import asyncio
 import logging
+import secrets
+import string
 import sys
+import time
 import traceback
+from types import MappingProxyType
 from typing import Any, Dict
 
+import aiohttp
+
 from .backoff import ExponentialBackoff
+from .errors import NodeSessionClosedError
 from .events import *
 from .stats import Stats
 
-
 __log__ = logging.getLogger(__name__)
 
+EventMapping = MappingProxyType(
+    {
+        "TrackEndEvent": ("on_track_end", TrackEnd(data)),
+        "TrackStartEvent": ("on_track_start", TrackStart(data)),
+        "TrackExceptionEvent": ("on_track_exception", TrackException(data)),
+        "TrackStuckEvent": ("on_track_stuck", TrackStuck(data)),
+        "WebSocketClosedEvent": ("on_websocket_closed", WebsocketClosed(data)),
+    }
+)
+
+
+class _TimedQueue(asyncio.Queue):
+    def __init__(self, maxsize=0, *, loop=None, timeout):
+        self._timeout = timeout
+        super().__init__(maxsize, loop=loop)
+
+    def _get(self):
+        item = self._queue.popleft()
+        StampDiff = time.time() - item[0]
+        if StampDiff > self._timeout:
+            return None
+        else:
+            return item[1]
+
+    def _put(self, item):
+        self._queue.append((time.time(), item))
+
+    def clear(self):
+        self._queue.clear()
+
+class _Key:
+    def __init__(self, Len: int = 32):
+        self.Len: int = Len
+        self.persistent: str = ""
+        self.__repr__()
+
+    def __repr__(self):
+        """Generate a new key, return it and make it persistent"""
+        alphabet = string.ascii_letters + string.digits + "#$%&()*+,-./:;<=>?@[]^_~!"
+        key = ''.join(secrets.choice(alphabet) for i in range(self.Len))
+        self.persistent = key
+        return key
+
+    def __str__(self):
+        """Return the persistent key."""
+        # Ensure output is not a non-string
+        # Since input could be Any object.
+        if not self.persistent:
+            return self.__repr__()
+        return str(self.persistent)
 
 class WebSocket:
 
@@ -47,20 +102,61 @@ class WebSocket:
         self.shard_count = attrs.get('shard_count')
         self.user_id = attrs.get('user_id')
         self.secure = attrs.get('secure')
+        # Send queue regardless of session resume.
+        # Operations take 20 to 1 ms
+        self.payload_timeout = attrs.get('payload_timeout')
+        self.session_resumed = False # To check if the session was resumed.
+        self.resume_session = attrs.get('resume_session')
+        if self.resume_session:
+            self.resume_timeout = attrs.get('resume_timeout')
+            # self.resume_key is casted to str to allow a Key object with __repr__ method.
+            # Useful if the class implements it's own method to generate keys.
+            # logger's level should be set to warning if stdout is vulnurable. eg: shared VPS
+            # As resuming key is logged.
+            self.resume_key = attrs.get('resume_key')
+            if self.resume_key is None:
+                self.resume_key = self._gen_key()
 
+        self._can_resume = False
+        # Dont initialze when not used.
+        if self.resume_session:
+            self._queue = _TimedQueue(0, loop=self.client.loop, timeout=self.payload_timeout)
         self._websocket = None
         self._last_exc = None
         self._task = None
 
     @property
-    def headers(self):
-        return {'Authorization': self.password,
+    def headers(self) -> dict:
+        base = {'Authorization': self.password,
                 'Num-Shards': str(self.shard_count),
                 'User-Id': str(self.user_id)}
+        if not self._can_resume:
+            return base
+        elif self._can_resume:
+            return base.update({'Resume-Key': str(self.resume_key)})
 
     @property
     def is_connected(self) -> bool:
         return self._websocket is not None and not self._websocket.closed
+
+    def _gen_key(self, Len=32):
+        if self.resume_key is None:
+            return _Key()
+        else:
+            # if this is a class then it will generate a persistent key
+            # We should not't check the instance since
+            # we would still make 1 extra call to check, which is useless.
+            self.resume_key.__repr__()
+            return self.resume_key
+
+    async def _configure_resume(self) -> None:
+        if self._can_resume:
+            return
+        elif self.resume_session:
+            await self._send(op='configureResuming', key=str(self.resume_key), timeout=self.resume_timeout)
+            __log__.info(f"WEBSOCKET | {repr(self._node)} | Resuming configured with Key {self.resume_key}")
+            self._can_resume = True
+            return
 
     async def _connect(self):
         await self.bot.wait_until_ready()
@@ -73,20 +169,36 @@ class WebSocket:
 
             if not self.is_connected:
                 self._websocket = await self._node.session.ws_connect(uri, headers=self.headers, heartbeat=self._node.heartbeat)
+                # If header not present then account for possibilty that session is resumed.
+                # if First connect then this will be false.
+                self.session_resumed = self._websocket._response.headers.get('Session-Resumed', self._can_resume)
+                if not self.session_resumed and self._can_resume:
+                    raise NodeSessionClosedError(f'{repr(self._node)} | Session was closed due to timeout. All Players may have been disconnected')
+                elif self.session_resumed:
+                    __log__.info(f"WEBSOCKET | {repr(self._node)} | Resumed Session with key: {self.resume_key}")
+
+        except NodeSessionClosedError:
+            __log__.warning(f"WEBSOCKET | {repr(self._node)} | Closed Session due to timeout.") # Error Not Fatal enough to return
+            # This exception raised when we can resume hence queue is initialized.
+            self._queue.clear() # Clear queue
+            # Generate a new key
+            self.resume_key = self._gen_key()
+            self._can_resume = False
+            self.client.loop.create_task(self._configure_resume())
 
         except Exception as error:
+            self._can_resume = False
             self._last_exc = error
             self._node.available = False
-
             if isinstance(error, aiohttp.WSServerHandshakeError) and error.status == 401:
-                print(f'\nAuthorization Failed for Node:: {self._node}\n', file=sys.stderr)
+                __log__.critical(f'\nAuthorization Failed for Node:: {self._node}\n')
             else:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
             return
 
         if not self._task:
-            self._task = self.bot.loop.create_task(self._listen())
+            self._task = self.client.loop.create_task(self._listen())
 
         self._last_exc = None
         self._closed = False
@@ -95,10 +207,18 @@ class WebSocket:
         if self.is_connected:
             await self.client._dispatch_listeners('on_node_ready', self._node)
             __log__.debug('WEBSOCKET | Connection established...%s', self._node.__repr__())
+            if not self._can_resume:
+                self.client.loop.create_task(self._configure_resume())
+            if self.session_resumed:
+                # Send only on resume.
+                self.client.loop.create_task(self._send_queue())
 
     async def _listen(self):
         backoff = ExponentialBackoff(base=7)
-
+        # This is an approximatly the no. of seconds we have been disconnected for.
+        # This is the easiest implementation, other ways are more sophisticated
+        # but we shalln't add attrs to class or globals as disconnects are usually rare.
+        down_time = 0.0
         while True:
             msg = await self._websocket.receive()
 
@@ -107,15 +227,20 @@ class WebSocket:
 
                 self._closed = True
                 retry = backoff.delay()
+                if self._can_resume and retry >= self.resume_timeout and down_time < self.timeout:
+                    backoff._exp = 0
+                    retry = backoff.delay()
 
                 __log__.warning(f'\nWEBSOCKET | Connection closed:: Retrying connection in <{retry}> seconds\n')
+                down_time += retry
 
                 await asyncio.sleep(retry)
                 if not self.is_connected:
-                    self.bot.loop.create_task(self._connect())
+                    self.client.loop.create_task(self._connect())
             else:
+                down_time = 0.0
                 __log__.debug(f'WEBSOCKET | Received Payload:: <{msg.data}>')
-                self.bot.loop.create_task(self.process_data(msg.json()))
+                self.client.loop.create_task(self.process_data(msg.json()))
 
     async def process_data(self, data: Dict[str, Any]):
         op = data.get('op', None)
@@ -130,7 +255,11 @@ class WebSocket:
             except KeyError:
                 return
 
-            listener, payload = self._get_event_payload(data['type'], data)
+            try:
+                listener, payload = EventMapping[data['type']]
+            except KeyError:
+                __log__.exception('Unknown Event received!')
+                return
 
             __log__.debug(f'WEBSOCKET | op: event:: {data}')
 
@@ -150,19 +279,59 @@ class WebSocket:
             except KeyError:
                 pass
 
-    def _get_event_payload(self, name: str, data):
-        if name == 'TrackEndEvent':
-            return 'on_track_end', TrackEnd(data)
-        elif name == 'TrackStartEvent':
-            return 'on_track_start', TrackStart(data)
-        elif name == 'TrackExceptionEvent':
-            return 'on_track_exception', TrackException(data)
-        elif name == 'TrackStuckEvent':
-            return 'on_track_stuck', TrackStuck(data)
-        elif name == 'WebSocketClosedEvent':
-            return 'on_websocket_closed', WebsocketClosed(data)
+    async def _send_queue(self):
+        # send while connected, resume on reconnect
+        while self.is_connected:
+            try:
+                data = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            if data is not None:
+                await self._send(**data.payload)
+            else:
+                pass
 
     async def _send(self, **data):
         if self.is_connected:
             __log__.debug(f'WEBSOCKET | Sending Payload:: {data}')
             await self._websocket.send_json(data)
+        elif self.resume_session:
+            __log__.debug(f'WEBSOCKET | Queueing Payload:: {data}')
+            # we don't need to catch QueueFull as maxsize is 0
+            self._queue.put_nowait(data)
+
+    async def close(self):
+        # Lavalink server currently doesn't close session immediately on 1000 (if session resuming is enabled)
+        # so we send a payload to disable resuming. It has been documented in lavalink implementation guide.
+        # TODO: Remove disable payload when Lavalink adds 1000 functionality
+        if self._can_resume:
+            await self._send(op='configureResuming', key=None)
+        await self._websocket.close(message=b'Node destroy request.')
+        self._closed = True
+        self._node.available = False
+        # We have disabled resuming.
+        self._can_resume = False
+        __log__.debug("WEBSOCKET | Closed websocket connection gracefully with code 1000.")
+        return
+
+    async def reset(self):
+        if isinstance(self.resume_key, str):
+            pass
+        elif isinstance(self.resume_key, _Key):
+            self.resume_key = None
+            self.resume_key = self._gen_key()
+        else:
+            pass
+
+        if self.resume_session:
+            self._can_resume = False
+            self._queue.clear()
+
+        try:
+            self._task.cancel()
+        except Exception:
+            __log__.debug("Error while cancelling task", exc_info=True)
+        finally:
+            self._task = None
+        await self.close()
+        await self._connect()

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -171,7 +171,7 @@ class WebSocket:
                 self._websocket = await self._node.session.ws_connect(uri, headers=self.headers, heartbeat=self._node.heartbeat)
                 # If header not present then account for possibilty that session is resumed.
                 # if First connect then this will be false.
-                self.session_resumed = self._websocket._response.headers.get('Session-Resumed', self._can_resume)
+                self.session_resumed = self._websocket._response.headers.get('Session-Resumed', False)
                 if not self.session_resumed and self._can_resume:
                     raise NodeSessionClosedError(f'{repr(self._node)} | Session was closed due to timeout. All Players may have been disconnected')
                 elif self.session_resumed:

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -131,9 +131,10 @@ class WebSocket:
                 'Num-Shards': str(self.shard_count),
                 'User-Id': str(self.user_id)}
         if not self._can_resume:
-            return base
+            pass
         elif self._can_resume:
-            return base.update({'Resume-Key': str(self.resume_key)})
+            base.update({'Resume-Key': str(self.resume_key)})
+        return
 
     @property
     def is_connected(self) -> bool:
@@ -192,8 +193,6 @@ class WebSocket:
             self._node.available = False
             if isinstance(error, aiohttp.WSServerHandshakeError) and error.status == 401:
                 __log__.critical(f'\nAuthorization Failed for Node:: {self._node}\n')
-                if self.resume_session:
-                    self.resume_key = self._gen_key() # Auth maybe due to key, so we change it immidiately
             else:
                 __log__.error(f'WEBSOCKET | Connection Failure:: {error}')
                 traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -134,7 +134,7 @@ class WebSocket:
             pass
         elif self._can_resume:
             base.update({'Resume-Key': str(self.resume_key)})
-        return
+        return base
 
     @property
     def is_connected(self) -> bool:


### PR DESCRIPTION
This is #59 but i kind of squashed all the commits.

## Added New attributes
- `Websocket.resume_session`: **bool**
- `Websocket.resume_timeout`: **float**
- `Websocket.resume_key`: **Union[str, `wavelink.websocket._Key`, object]** _(Best left None)_
- `Websocket.payload_timeout`: **float** _This is basically how recent requests shall be sent to the server_
- `Websocket.reset()` method.
- `Websocket.close()` method.
- `Node.heartbeat`: **float**
- `wavelink.errors.NodeSessionClosedError`: _This error is handled within wavelink, but a warning message is logged for now_
- **Other private attributes**:
  - `Websocket._send_queue` method: _called on connect if session is resumed_
  - `Websocket._can_resume`: wether resuming is enabled and configured.
  - `Websocket._queue`: _Present only is `Websocket.resume_session` is `True`_
  - `wavelink.websocket._TimedQueue`: _An `asyncio.Queue` subclass, which stores data only for a certain amount of time_
  - `wavelink.websocket._Key`: _The default key, this generates secure passwords, any other classes must be similar in functionality_
  - **`Node` Attributes**: _pass the arguments to `Node.connect` method._
    - `Node._resume_session`
    - `Node._resume_timeout`
    - `Node._payload_timeout`
    - `Node._resume_key`

## Example
- ### Basic
```py
async def start_nodes(self) -> None:
    """Connect and intiate nodes."""
    nodes = {'MAIN': {'host': 'lavaserver.badhost.com',
                      'port': 80,
                      'rest_uri': 'http://lavaserver.badhost.com',
                      'password': "verytrivialpassword",
                      'identifier': 'MAIN',
                      'region': 'us_central',
                      'resume_session': True # rest is default
                      }}

    for n in nodes.values():
        await self.bot.wavelink.initiate_node(**n)
```
- ### Complete
**Key.py**
```py
from somewhere import SomeSecurePasswordGenerator

class key:
    def __init__(self, len):
        self.len = len
        self.persistent = None
        self.__repr__()

    def __str__(self):
        return self.persistent

    def __repr__(self):
        """This should generate a key and shall make it persistent """
        self.persistent = SomeSecurePasswordGenerator(self.len)
        return self.persistent
```
***music_cog.py***
```py
from Key import key 
...

class my_cog(commands.Cog):
     ...

     async def start_nodes(self) -> None:
        """Connect and intiate nodes."""
        nodes = {'MAIN': {'host': 'lavaserver.badhost.com',
                          'port': 80,
                          'rest_uri': 'http://lavaserver.badhost.com',
                          'password': "verytrivialpassword",
                          'identifier': 'MAIN',
                          'region': 'us_central',
                          'heartbeat': 40.0, # ping the server every 40s
                          'resume_session': True,
                          'resume_timeout': 90.0,
                          'resume_key': key(10) # or "Astring".
                          'payload_timeout': 40.0
                          }}

        for n in nodes.values():
            await self.bot.wavelink.initiate_node(**n)
    
    ...
```
## New features proposed in this PR
### Resuming
When the bot disconnects from the node (eg: 1006) then the lavalink server keeps on playing the music until session timeout, this allows the bot to reconnect and take control of the session. This PR implements [this lavalink feature](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md#resuming-lavalink-sessions).
#### Key protocol
  The key must be an `object` instance or a `str`. The `__repr__` method should return a new key. The `__str__`method **must** return the last key that was generated by `__repr__`. This protocol only defines these two methods since it needs to maintain compatibilty with `str`.

### Queueing
After the Node disconnects, we try to reconnect multiple times with a capped backoff before timeout. during this time the requests to the node are queued in an `asyncio.Queue` subclass whose payload expires after some time.
This could be useful when you have an high timeout but want to only send recent requests.

### Semver
This is a minor change.  _The changes are not breaking, assuming no-one initializes Node instances directly._

