### PR TITLE
Remove loop kwarg to aiohttp

### DIFF
--- a/wavelink/client.py
+++ b/wavelink/client.py
@@ -66,7 +66,7 @@ class Client:
     def __init__(self, bot: Union[commands.Bot, commands.AutoShardedBot]):
         self.bot = bot
         self.loop = bot.loop or asyncio.get_event_loop()
-        self.session = aiohttp.ClientSession(loop=self.loop)
+        self.session = aiohttp.ClientSession()
 
         self.nodes = {}
 


### PR DESCRIPTION
This fixes compatibility with aiohttp 4.0.0a1 and is redundant anyways.

aiohttp 3.6 will use `get_event_loop()` by default then (https://github.com/aio-libs/aiohttp/blob/3.6/aiohttp/client.py#L213) and aiohttp 4 does that always (https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L206).

This is backwards compatible unless someone has two event loops for running stuff in a different thread, which is unlikely.