### PR TITLE
Fix useless math in advanced example.

### DIFF
--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -438,7 +438,7 @@ class Music(commands.Cog, wavelink.WavelinkMixin):
         required = math.ceil((len(channel.members) - 1) / 2.5)
 
         if ctx.command.name == 'stop':
-            if len(channel.members) - 1 == 2:
+            if len(channel.members) == 3:
                 required = 2
 
         return required


### PR DESCRIPTION
This PR fixes some useless math in the `advanced` example