### PR TITLE
Change python requirement to 3.9

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,6 +1,6 @@
 Installing
 ============
-WaveLink requires Python 3.8+.
+WaveLink requires Python 3.9+.
 You can download the latest version of Python `here <https://www.python.org/downloads/>`_.
 
 **Windows:**


### PR DESCRIPTION
The python requirement is outdated, as for example  wavelink.YouTubeTrack.search() uses [removeprefix](https://dev.to/delta456/python-removeprefix-and-removesuffix-34jp).