### PR TITLE
Spotify Iterator / Spotify search returns YouTubeTrack

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -31,8 +31,8 @@ from typing import List, Optional, Type, TypeVar, Union
 import aiohttp
 from discord.ext import commands
 
-import wavelink
 from wavelink import Node, NodePool, PartialTrack, YouTubeTrack
+from wavelink.tracks import SearchableTrack
 from wavelink.utils import MISSING
 
 
@@ -152,7 +152,7 @@ class SpotifyAsyncIterator:
         if self._partial:
             track = PartialTrack(query=f'{track["name"]} - {track["artists"][0]["name"]}')
         else:
-            track = (await wavelink.YouTubeTrack.search(query=f'{track["name"]} -'
+            track = (await SpotifyTrack.search(query=f'{track["name"]} -'
                                                               f' {track["artists"][0]["name"]}'))[0]
 
         self._count += 1
@@ -218,7 +218,7 @@ class SpotifyClient:
                       query: str,
                       type: SpotifySearchType = SpotifySearchType.track,
                       iterator: bool = False,
-                      ) -> Optional[List[YouTubeTrack]]:
+                      ) -> Optional[List['SpotifyTrack']]:
 
         if not self._bearer_token or time.time() >= self._expiry:
             await self._get_bearer_token()
@@ -237,11 +237,11 @@ class SpotifyClient:
             data = await resp.json()
 
             if data['type'] == 'track':
-                return await wavelink.YouTubeTrack.search(f'{data["name"]} - {data["artists"][0]["name"]}')
+                return await SpotifyTrack.search(f'{data["name"]} - {data["artists"][0]["name"]}')
 
             elif data['type'] == 'album' and iterator is False:
                 tracks = data['tracks']['items']
-                return [(await wavelink.YouTubeTrack.search(f'{t["name"]} - {t["artists"][0]["name"]}'))[0]
+                return [(await SpotifyTrack.search(f'{t["name"]} - {t["artists"][0]["name"]}'))[0]
                         for t in tracks]
 
             elif data['type'] == 'playlist' and iterator is False:
@@ -250,7 +250,7 @@ class SpotifyClient:
 
                 for track in tracks:
                     t = track['track']
-                    ret.append((await wavelink.YouTubeTrack.search(f'{t["name"]} - {t["artists"][0]["name"]}'))[0])
+                    ret.append((await SpotifyTrack.search(f'{t["name"]} - {t["artists"][0]["name"]}'))[0])
 
                 return ret
 

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -228,7 +228,7 @@ class SpotifyClient:
         if not regex_result:
             url = BASEURL.format(entity=type.name, identifier=query)
         else:
-            url = BASEURL.format(entity=regex_result['entity'], identifier=regex_result['id'])
+            url = BASEURL.format(entity=regex_result['type'], identifier=regex_result['id'])
 
         async with self.session.get(url, headers=self.bearer_headers) as resp:
             if resp.status != 200:


### PR DESCRIPTION
`SpotifyAsyncIterator` and `SpotifyTrack.search` now returns SpotifyTrack instead of `wavelink.YouTubeTrack`

Fix KeyError in Spotify ext, not fixed at e445e4c