### PR TITLE
Return none instead of raising IndexError

### DIFF
--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -194,6 +194,8 @@ class SearchableTrack(Track, Searchable):
             tracks = await node.get_tracks(cls, f"{cls._search_type}:{query}")
 
         if return_first:
+            if not tracks:
+                return None
             return tracks[0]
 
         return tracks


### PR DESCRIPTION
This will remove the need for a `try except` block around the search function with the `return_first=True` parameter