### PR TITLE
Update player.py to work with dpy2.0

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -167,9 +167,7 @@ class Player(discord.VoiceProtocol):
             )
 
     async def connect(self, *, timeout: float, reconnect: bool, **kwargs: Any) -> None:
-        self_mute = kwargs.pop("self_mute", False)
-        self_deaf = kwargs.pop("self_deaf", False)
-        await self.guild.change_voice_state(channel=self.channel, self_mute=self_mute, self_deaf=self_deaf)
+        await self.guild.change_voice_state(channel=self.channel, **kwargs)
         self._connected = True
 
         logger.info(f"Connected to voice channel:: {self.channel.id}")

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -199,7 +199,7 @@ class Player(discord.VoiceProtocol):
         channel: :class:`discord.VoiceChannel`
             The channel to move to. Must be a voice channel.
         """
-        await self.guild.change_voice_state(channel=channel)
+        await self.guild.change_voice_state(channel=channel, self_mute=False, self_deaf=False)
         logger.info(f"Moving to voice channel:: {channel.id}")
 
     async def play(

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -197,7 +197,7 @@ class Player(discord.VoiceProtocol):
         channel: :class:`discord.VoiceChannel`
             The channel to move to. Must be a voice channel.
         """
-        await self.guild.change_voice_state(channel=channel, self_mute=False, self_deaf=False)
+        await self.guild.change_voice_state(channel=channel)
         logger.info(f"Moving to voice channel:: {channel.id}")
 
     async def play(

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -166,8 +166,10 @@ class Player(discord.VoiceProtocol):
                 op="voiceUpdate", guildId=str(self.guild.id), **voice_state
             )
 
-    async def connect(self, *, timeout: float, reconnect: bool) -> None:
-        await self.guild.change_voice_state(channel=self.channel)
+    async def connect(self, *, timeout: float, reconnect: bool, **kwargs: Any) -> None:
+        self_mute = kwargs.pop("self_mute", False)
+        self_deaf = kwargs.pop("self_deaf", False)
+        await self.guild.change_voice_state(channel=self.channel, self_mute=self_mute, self_deaf=self_deaf)
         self._connected = True
 
         logger.info(f"Connected to voice channel:: {self.channel.id}")


### PR DESCRIPTION
This adds a `**kwargs` consumption parameter to `Player.connect` and the subsequent call to method internals.

I opted for `**kwargs` both for backwards compatibility and inter-library usage.

The "fix" currently is to provide both `self_mute` and `self_deaf` kwargs to the method call. Please let me know if you'd like a better method.