### PR TITLE
Fix SearchableTrack search method raising IndexError when no tracks match the query

### DIFF
--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -193,6 +193,9 @@ class SearchableTrack(Track, Searchable):
         else:
             tracks = await node.get_tracks(cls, f"{cls._search_type}:{query}")
 
+        if not tracks:
+            raise commands.BadArgument("Could not find any songs matching that query.")
+
         if return_first:
             return tracks[0]
 


### PR DESCRIPTION
The search method currently either returns an empty list or triggers an `IndexError` depending on the `return_first` argument. This should make the code a little more consistent.