### PR TITLE
Fix Bug when return_first parameter is True

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -150,10 +150,11 @@ class SpotifyAsyncIterator:
             return await self.__anext__()
 
         if self._partial:
-            track = PartialTrack(query=f'{track["name"]} - {track["artists"][0]["name"]}')
+            track = PartialTrack(
+                query=f'{track["name"]} - {track["artists"][0]["name"]}')
         else:
             track = (await wavelink.YouTubeTrack.search(query=f'{track["name"]} -'
-                                                              f' {track["artists"][0]["name"]}'))[0]
+                                                              f' {track["artists"][0]["name"]}', return_first=True))
 
         self._count += 1
         return track
@@ -228,7 +229,8 @@ class SpotifyClient:
         if not regex_result:
             url = BASEURL.format(entity=type.name, identifier=query)
         else:
-            url = BASEURL.format(entity=regex_result['type'], identifier=regex_result['id'])
+            url = BASEURL.format(
+                entity=regex_result['type'], identifier=regex_result['id'])
 
         async with self.session.get(url, headers=self.bearer_headers) as resp:
             if resp.status != 200:
@@ -357,7 +359,8 @@ class SpotifyTrack(YouTubeTrack):
         """
 
         if type is not SpotifySearchType.album and type is not SpotifySearchType.playlist:
-            raise TypeError("Iterator search type must be either album or playlist.")
+            raise TypeError(
+                "Iterator search type must be either album or playlist.")
 
         if node is MISSING:
             node = NodePool.get_node()
@@ -373,6 +376,7 @@ class SpotifyTrack(YouTubeTrack):
         results = await cls.search(argument)
 
         if not results:
-            raise commands.BadArgument("Could not find any songs matching that query.")
+            raise commands.BadArgument(
+                "Could not find any songs matching that query.")
 
         return results[0]

--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -194,7 +194,10 @@ class SearchableTrack(Track, Searchable):
             tracks = await node.get_tracks(cls, f"{cls._search_type}:{query}")
 
         if return_first:
-            return tracks[0]
+            if tracks:
+                return tracks[0]
+            else:
+                return []
 
         return tracks
 
@@ -210,7 +213,8 @@ class SearchableTrack(Track, Searchable):
         results = await cls.search(argument)
 
         if not results:
-            raise commands.BadArgument("Could not find any songs matching that query.")
+            raise commands.BadArgument(
+                "Could not find any songs matching that query.")
 
         if isinstance(cls, YouTubePlaylist):
             return results  # type: ignore
@@ -262,7 +266,8 @@ class YouTubePlaylist(SearchableTrack, Playlist):
         self.tracks: List[YouTubeTrack] = []
         self.name: str = data["playlistInfo"]["name"]
 
-        self.selected_track: Optional[int] = data["playlistInfo"].get("selectedTrack")
+        self.selected_track: Optional[int] = data["playlistInfo"].get(
+            "selectedTrack")
         if self.selected_track is not None:
             self.selected_track = int(self.selected_track)
 
@@ -307,7 +312,8 @@ class PartialTrack(Searchable, Playable):
         self._cls = cls
 
         if not issubclass(cls, SearchableTrack):
-            raise TypeError(f"cls parameter must be of type {SearchableTrack!r} not {cls!r}")
+            raise TypeError(
+                f"cls parameter must be of type {SearchableTrack!r} not {cls!r}")
 
     async def _search(self):
         node = self._node


### PR DESCRIPTION
When the return_first parameter is set to True and no tracks are found the code raised an IndexError.

Fix:- I added a check if the tracks are empty then an empty list will be returned

Also,
In the spotify extention when a SpotyfyIterator gets the next element it can raise IndexError as insted of return_first direct index is used so I replaced index with the return_first parameter