### PR TITLE
Add own __str__ for YouTubePlaylist

### DIFF
--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -270,6 +270,9 @@ class YouTubePlaylist(SearchableTrack, Playlist):
             track = YouTubeTrack(track_data["track"], track_data["info"])
             self.tracks.append(track)
 
+    def __str__(self) -> str:
+        return self.name
+
 
 class LocalTrack(SearchableTrack):
     """Represents a Lavalinkl Local Track Object."""


### PR DESCRIPTION
This adds an own __str__ function for the YouTubePlaylist as it has no title, so print(YouTubePlaylist) doesn't raise an AttributeError.