### PR TITLE
node: fix typo in Node.get_playlist docstring

### DIFF
--- a/wavelink/pool.py
+++ b/wavelink/pool.py
@@ -225,7 +225,7 @@ class Node:
     async def get_playlist(self, cls: Type[PLT], identifier: str) -> Optional[PLT]:
         """|coro|
 
-        Search for an return a :class:`abc.Playlist` given an identifier.
+        Search for and return a :class:`abc.Playlist` given an identifier.
 
         Parameters
         ----------


### PR DESCRIPTION
I just fixed a small typo (a missing `d`) in the docstring of `Node.get_playlist`