### PR TITLE
Updated volume validation and docstrings in Player.set_volume and default value of Player.volume

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -95,7 +95,7 @@ class Player(discord.VoiceProtocol):
         self.last_update: datetime.datetime = MISSING
         self.last_position: float = MISSING
 
-        self.volume: float = 100
+        self.volume: float = 1.0
         self._paused: bool = False
         self._source: Optional[abc.Playable] = None
         self._filter = None

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -306,20 +306,20 @@ class Player(discord.VoiceProtocol):
         """
         await self.set_pause(False)
 
-    async def set_volume(self, volume: int, seek: bool = False) -> None:
+    async def set_volume(self, volume: float = 1.0, seek: bool = False) -> None:
         """|coro|
 
-        Set the player's volume, between 0 and 1000.
+        Set the player's volume, between 0.001 and 5.0.
 
         Parameters
         ----------
-        volume: int
-            The volume to set the player to.
+        volume: float
+            The volume to set the player to. Can be left blank to reset it to the default volume (1.0).
         seek: bool
             Whether to seek the player which will set the new volume immediately. Defaults to ``False``.
         """
-
-        self.volume = max(min(volume, 1000), 0)
+        
+        self.volume = max(min(volume, 5.0), 0.0)
         await self.set_filter(Filter(self._filter, volume=self.volume), seek=seek)
 
     async def seek(self, position: int = 0) -> None:


### PR DESCRIPTION
In conjunction with the deprecation from the `volume` op and the change to the `filter` op, I have reupdated the validation in the [`Player.set_volume`](https://github.com/mccoderpy/Wavelink/blob/6fa84b2ee3d4f18171a8602f45bc06ec85808f8d/wavelink/player.py#L309) to the new (range 0.001 - 5.0).

I also changed the annotation from `volume` to `float` and set a default value of 1.0.

The default value of [`Playler.volume`](https://github.com/mccoderpy/Wavelink/blob/6fa84b2ee3d4f18171a8602f45bc06ec85808f8d/wavelink/player.py#L98) was also changed from `1000` to `1.0`.

- [x] Updated related docstrings
- [x] Tested changes that were made