### PR TITLE
player/seek: Remove mention of 'None' for seeking.

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -330,7 +330,7 @@ class Player(discord.VoiceProtocol):
         Parameters
         ----------
         position: int
-            The position as an int in milliseconds to seek to. Could be None to seek to beginning.
+            The position as an int in milliseconds to seek to.
         """
         await self.node._websocket.send(
             op="seek", guildId=str(self.guild.id), position=position


### PR DESCRIPTION
There doesn't appear to be any special handling for `None` here, so this is actually sent straight to Lavalink as a `null` value, which Lavalink doesn't support and will throw an error for.