### PR TITLE
Add payload_args optional argument to the play method in player.py

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -242,8 +242,8 @@ class Player(discord.VoiceProtocol):
             Defaults to ``None`` which will not change the volume.
         pause: bool
             Changes the players pause state. Defaults to ``None`` which will not change the pause state.
-        payload_args: Optional[dict]
-            Additional custom arguments to pass to the payload. Defaults to ``{}``.
+        payload_args: Optional[Dict]
+            Additional custom arguments to pass to the payload. 
 
 
         Returns

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -219,7 +219,7 @@ class Player(discord.VoiceProtocol):
         end: Optional[int] = None,
         volume: Optional[int] = None,
         pause: Optional[bool] = None,
-        payload_args: Optional[dict] = {},
+        payload_args: Optional[Dict] = None,
     ):
         """|coro|
 
@@ -278,8 +278,8 @@ class Player(discord.VoiceProtocol):
         if pause is not None:
             self._paused = pause
             payload["pause"] = pause
-
-        payload.update(payload_args)
+        if payload_args is not None:
+            payload.update(payload_args)
 
         await self.node._websocket.send(**payload)
 

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -219,6 +219,7 @@ class Player(discord.VoiceProtocol):
         end: Optional[int] = None,
         volume: Optional[int] = None,
         pause: Optional[bool] = None,
+        payload_args: Optional[dict] = {},
     ):
         """|coro|
 
@@ -241,6 +242,9 @@ class Player(discord.VoiceProtocol):
             Defaults to ``None`` which will not change the volume.
         pause: bool
             Changes the players pause state. Defaults to ``None`` which will not change the pause state.
+        payload_args: Optional[dict]
+            Additional custom arguments to pass to the payload. Defaults to ``{}``.
+
 
         Returns
         -------
@@ -274,6 +278,8 @@ class Player(discord.VoiceProtocol):
         if pause is not None:
             self._paused = pause
             payload["pause"] = pause
+
+        payload.update(payload_args)
 
         await self.node._websocket.send(**payload)
 


### PR DESCRIPTION
This argument allows the user to pass arguments which will be directly sent to Lavalink in the play method. This gives the ability to interact with Lavalink plugins