### PR TITLE
Fixed small type issue & make spotify track attr consistent with other tracks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Wavelink"
-version = "2.0.0b3"
+version = "2.0.0b4"
 authors = [
   { name="EvieePy", email="evieepy@gmail.com" },
 ]

--- a/wavelink/__init__.py
+++ b/wavelink/__init__.py
@@ -25,7 +25,7 @@ __title__ = "WaveLink"
 __author__ = "PythonistaGuild, EvieePy"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019-Present (c) PythonistaGuild, EvieePy"
-__version__ = "2.0.0b3"
+__version__ = "2.0.0b4"
 
 from .enums import *
 from .exceptions import *

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -169,7 +169,7 @@ class SpotifyRequestError(Exception):
         The reason the request failed. Could be None.
     """
 
-    def __init__(self, status: int, reason: str = None):
+    def __init__(self, status: int, reason: Optional[str] = None):
         self.status = status
         self.reason = reason
 

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -199,8 +199,8 @@ class SpotifyTrack:
         The spotify ID for this track.
     isrc: str
         The International Standard Recording Code associated with this track.
-    duration: int
-        The track duration in milliseconds.
+    length: int
+        The track length in milliseconds.
     """
 
     def __init__(self, data: dict[str, Any]) -> None:
@@ -218,7 +218,7 @@ class SpotifyTrack:
         self.title: str = self.name
         self.uri: str = data['uri']
         self.id: str = data['id']
-        self.duration: int = data['duration_ms']
+        self.length: int = data['duration_ms']
 
         self.isrc: str = data['external_ids']['isrc']
 

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -201,6 +201,8 @@ class SpotifyTrack:
         The International Standard Recording Code associated with this track.
     length: int
         The track length in milliseconds.
+    duration: int
+        Alias to length.
     """
 
     def __init__(self, data: dict[str, Any]) -> None:
@@ -219,6 +221,7 @@ class SpotifyTrack:
         self.uri: str = data['uri']
         self.id: str = data['id']
         self.length: int = data['duration_ms']
+        self.duration: int = self.length
 
         self.isrc: str = data['external_ids']['isrc']
 


### PR DESCRIPTION
Fixed a small type issue in SpotifyRequestError and renamed the SpotifyTrack.duration attribute to SpotifyTrack.length attribute to make it consistent with other types of Tracks