### PR TITLE
Use Type instead of Optional in PartialTrack._cls

### DIFF
--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -303,7 +303,7 @@ class PartialTrack(Searchable, Playable):
                  *,
                  query: str,
                  node: Optional[Node] = MISSING,
-                 cls: Optional[SearchableTrack] = YouTubeTrack):
+                 cls: Type[SearchableTrack] = YouTubeTrack):
         self.query = query
         self.title = query
         self._node = node


### PR DESCRIPTION
Optional is just an alias for Union[x, None] which is not the desirable type in this case.
This has been causing my subclasses of PartialTrack to think code is unreachable after calling super().__init__() because the subclass check would conflict the typechecker.