### PR TITLE
Fix Queue._insert attribute error

### DIFF
--- a/wavelink/queue.py
+++ b/wavelink/queue.py
@@ -273,7 +273,7 @@ class Queue(BaseQueue):
         self._wakeup_next()
 
     def _insert(self, index: int, item: Playable | spotify.SpotifyTrack) -> None:
-        super()._queue.insert(index, item)
+        super()._insert(index, item)
         self._wakeup_next()
 
     def _wakeup_next(self) -> None:


### PR DESCRIPTION
```
Python 3.11.2
Wavelink==2.0.0b8
```
The simplest way to reproduce this is to call `player.queue.put_at_front(track)`

It looks like a copy-pasta bug.

**Traceback**
```
Traceback (most recent call last):
  File "C:\Users\senpos\PycharmProjects\gigabot\venv\Lib\site-packages\discord\app_commands\commands.py", line 841, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\senpos\PycharmProjects\gigabot\bot\cogs\music.py", line 46, in play
    player.queue.put_at_front(track)
  File "C:\Users\senpos\PycharmProjects\gigabot\venv\Lib\site-packages\wavelink\queue.py", line 205, in put_at_front
    self.put_at_index(0, item)
  File "C:\Users\senpos\PycharmProjects\gigabot\venv\Lib\site-packages\wavelink\queue.py", line 201, in put_at_index
    self._insert(index, self._check_playable(item))
  File "C:\Users\senpos\PycharmProjects\gigabot\venv\Lib\site-packages\wavelink\queue.py", line 276, in _insert
    super()._queue.insert(index, item)
    ^^^^^^^^^^^^^^
AttributeError: 'super' object has no attribute '_queue'
```