### PR TITLE
Use get for isrc instead of try except

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -224,10 +224,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
 
-        try:
-            self.isrc: str = data['external_ids']['isrc']
-        except KeyError:
-            self.isrc = None
+        self.isrc: str | None = data["external_ids"].get("isrc")
 
     def __eq__(self, other) -> bool:
         return self.id == other.id


### PR DESCRIPTION
This also fixes the following pyright issue and makes the code shorter:
```
Cannot assign member "isrc" for type "SpotifyTrack"
  Expression of type "str | None" cannot be assigned to member "isrc" of class "SpotifyTrack"
    Type "str | None" cannot be assigned to type "str"
      Type "None" cannot be assigned to type "str" 