### PR TITLE
Fix Player.set_filter seeking

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -549,7 +549,7 @@ class Player(discord.VoiceProtocol):
                                                              data=data)        
 
         if self.is_playing() and seek:
-            await self.seek(int(self.position * 1000))
+            await self.seek(int(self.position))
         logger.debug(f"Set filter:: {self._filter} ({self.channel.id})")
 
     async def _destroy(self) -> None:


### PR DESCRIPTION
When using `Player.set_filter` with `seek=True`, the current track would be skipped immediately because an invalid position was passed to `Player.seek`.

`self.position` is already in milliseconds, so there is no need to multiply it by 1000