### PR TITLE
Avoid KeyError when Spotify API does not return external IDs

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -239,7 +239,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
 
-        self.isrc: str | None = data["external_ids"].get("isrc")
+        self.isrc: str | None = data.get("external_ids", {}).get("isrc")
 
     def __eq__(self, other) -> bool:
         return self.id == other.id


### PR DESCRIPTION
Possible fix for https://github.com/PythonistaGuild/Wavelink/issues/209