### PR TITLE
Should get item after checking self.loop_all and self.is_empty

### DIFF
--- a/wavelink/queue.py
+++ b/wavelink/queue.py
@@ -261,11 +261,11 @@ class Queue(BaseQueue):
         if self.loop and self._loaded:
             return self._loaded
 
-        item = super()._get()
         if self.loop_all and self.is_empty:
             self._queue.extend(self.history._queue)
             self.history.clear()
-
+        item = super()._get()
+        
         self._loaded = item
         self.history.put(item)
 


### PR DESCRIPTION
Using loop_all loops only once, to loop endlessly item should be get after checking self.loop_all and self.is_empty condition
![image](https://user-images.githubusercontent.com/34966090/235321818-2deb1f3e-5951-451e-8358-6a8eb24d3897.png)
![image](https://user-images.githubusercontent.com/34966090/235321835-670f2215-7936-4e14-916e-b34a301c80c7.png)
