### PR TITLE
Fix ignore every WebSocketClosedEvent

### DIFF
--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -192,8 +192,7 @@ class Websocket:
                     continue
 
                 if data['type'] == 'WebSocketClosedEvent':
-                    if data['code'] == 4014:
-                        continue
+                    continue
 
                 track = await self.node.build_track(cls=wavelink.GenericTrack, encoded=data['encodedTrack'])
                 payload: TrackEventPayload = TrackEventPayload(


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/minibot/venv/lib/python3.10/site-packages/wavelink/websocket.py", line 241, in _listen
    track = await self.node.build_track(cls=wavelink.GenericTrack, encoded=data['encodedTrack'])
KeyError: 'encodedTrack'

data: {"code":1000,"reason":"","byRemote":false,"guildId":"1047066927312408616","op":"event","type":"WebSocketClosedEvent"}
```

Removed `continue` only if the code is 4014 to prevent the `_listen` function from breaking.