### PR TITLE
Fixed bugs in ext.spotify.__init__.py

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -242,7 +242,10 @@ class SpotifyTrack:
         self.isrc: str | None = data.get("external_ids", {}).get("isrc")
 
     def __eq__(self, other) -> bool:
-        return self.id == other.id
+        if isinstance(other, SpotifyTrack):
+            return self.id == other.id
+
+        return False
 
     @classmethod
     async def search(

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -239,7 +239,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
 
-        self.isrc: str | None = data["external_ids"].get("isrc")
+        self.isrc: str | None = data.get("external_ids", {}).get("isrc")
 
     def __eq__(self, other) -> bool:
         return self.id == other.id
@@ -443,7 +443,7 @@ class SpotifyClient:
             data = await resp.json()
 
         if data['type'] == 'track':
-            return SpotifyTrack(data)
+            return [SpotifyTrack(data)]
 
         elif data['type'] == 'album':
             album_data: dict[str, Any]= {
@@ -490,4 +490,4 @@ class SpotifyClient:
                         url = data['next']
             else:
                 tracks = data['tracks']['items']
-                return [SpotifyTrack(t) for t in tracks]
+                return [SpotifyTrack(t['track']) for t in tracks]

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -275,10 +275,10 @@ class SpotifyTrack:
         if node is None:
             node: Node = NodePool.get_connected_node()
 
-        if type == SpotifySearchType.track:
-            tracks = await node._spotify._search(query=query, type=type)
-
-            return tracks[0] if return_first else tracks
+        # if type == SpotifySearchType.track:
+        #     tracks = await node._spotify._search(query=query, type=type)
+        #
+        #     return tracks[0] if return_first else tracks
         return await node._spotify._search(query=query, type=type)
 
     @classmethod
@@ -443,7 +443,7 @@ class SpotifyClient:
             data = await resp.json()
 
         if data['type'] == 'track':
-            return [SpotifyTrack(data)]
+            return SpotifyTrack(data)
 
         elif data['type'] == 'album':
             album_data: dict[str, Any]= {

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -141,6 +141,14 @@ class Node:
 
     def __eq__(self, other: object) -> bool:
         return self.id == other.id if isinstance(other, Node) else NotImplemented
+    
+    @property
+    def websocket(self) -> Websocket:
+        return self._websocket
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
When dealing with a single track it should return a list with a single item to avoid IndexError when use the parameter "return_first" in "SpotifyTrack.search()".
In "SpotifyTrack.__init__()" the key "external_ids" from "data" does not exist when searching for albums.
When dealing with playlists the "track" key must be implemented for each track in tracks list when creating SpotifyTrack objects.