### PR TITLE
Spotify Extension Fixes (Album/ISRC and minor issues)

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -198,8 +198,8 @@ class SpotifyTrack:
         The URI for this spotify track.
     id: str
         The spotify ID for this track.
-    isrc: str | None
-        The International Standard Recording Code associated with this track if given.
+    isrc: str
+        The International Standard Recording Code associated with this track.
     length: int
         The track length in milliseconds.
     duration: int

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -443,14 +443,31 @@ class SpotifyClient:
             return SpotifyTrack(data)
 
         elif data['type'] == 'album':
+            album_data: dict[str, Any]= {
+                                        'album_type': data['album_type'],
+                                        'artists': data['artists'],
+                                        'available_markets': data['available_markets'],
+                                        'external_urls': data['external_urls'],
+                                        'href': data['href'],
+                                        'id': data['id'],
+                                        'images': data['images'],
+                                        'name': data['name'],
+                                        'release_date': data['release_date'],
+                                        'release_date_precision': data['release_date_precision'],
+                                        'total_tracks': data['total_tracks'],
+                                        'type': data['type'],
+                                        'uri': data['uri'],
+                                        }
             tracks = []
             for track in data['tracks']['items']:
-                async with self.session.get(track['href'], headers=self.bearer_headers) as resp:
-                    if resp.status != 200:
-                        raise SpotifyRequestError(resp.status, resp.reason)
-                    tracks.append(track := await resp.json())
-            
-            return tracks if iterator else [SpotifyTrack(t) for t in tracks]
+                track['album'] = album_data
+                if iterator:
+                    tracks.append(track)
+                else:
+                    tracks.append(SpotifyTrack(track))
+
+            return tracks
+
 
         elif data['type'] == 'playlist':
             if iterator:


### PR DESCRIPTION
When requesting albums, the Spotify API only returns SimplifiedTrackObjects that do not contain all the track information received when requesting tracks or playlists. #197 attempted to resolved this by making the ISRC optional on SpotifyTracks. However, Wavelink uses the ISRC of SpotifyTracks in their fulfill function.  

```py
 try:
            tracks: list[cls] = await cls.search(f'"{self.isrc}"')
        except wavelink.NoTracksError:
            tracks: list[cls] = await cls.search(f'{self.name} - {self.artists[0]}')
```
In both #219 and my own observations these missing ISRC have resulted in the incorrect song to be repeatedly found. This PR would resolve the SimplifiedTrackObjects into full ones, preventing this issue, as well as end #209.

Additional it resolves the issue discussed in #221 without any breaking changes to those not using return_first. (On this change feel free to correct me if the instance check against SpotifyTrack is too narrow).

Finally, it would correct the minor error causing playlist searches to error when not using the iterator. 