### PR TITLE
Docs CSS and hoverxref update.

### DIFF
--- a/docs/_static/styles/furo.css
+++ b/docs/_static/styles/furo.css
@@ -94,10 +94,12 @@ body {
     --color-api-pre-name: var(--color-problematic);
     --color-api-paren: var(--color-foreground-secondary);
     --color-api-keyword: var(--color-foreground-primary);
-    --color-highlight-on-target: #ffc;
+    --color-highlight-on-target: #ffe0fc;
     --color-inline-code-background: var(--color-background-secondary);
     --color-highlighted-background: #def;
     --color-highlighted-text: var(--color-foreground-primary);
+    --color-code-background: #a69cce;
+    --color-codeblock-background: #f8f4ff;
     --color-guilabel-background: #ddeeff80;
     --color-guilabel-border: #bedaf580;
     --color-guilabel-text: var(--color-foreground-primary);
@@ -141,9 +143,6 @@ body {
     --color-scroll-thumb: #cecece;
 }
 
-.highlight {
-    background-color: #F6F6F6;
-}
 
 .class > .sig-object {
     border-left: #0e84b5 solid 3px;
@@ -473,6 +472,7 @@ html body .only-dark {
         --color-card-border: var(--color-background-secondary);
         --color-card-background: #18181a;
         --color-card-marginals-background: var(--color-background-hover);
+        --color-codeblock-background: #1f1e23;
     }
 
     html body[data-theme=dark] .only-light {
@@ -503,13 +503,14 @@ html body .only-dark {
             --color-guilabel-background: #08356380;
             --color-guilabel-border: #13395f80;
             --color-api-keyword: var(--color-foreground-secondary);
-            --color-highlight-on-target: #330;
+            --color-highlight-on-target: #322e3f;
             --color-admonition-background: #18181a;
             --color-card-border: var(--color-background-secondary);
             --color-card-background: #18181a;
             --color-card-marginals-background: var(--color-background-hover);
             --color-scroll-background: #383838;
-            --color-scroll-thumb: #606060
+            --color-scroll-thumb: #606060;
+            --color-codeblock-background: #1f1e23;
         }
 
         html body:not([data-theme=light]) .only-light {
@@ -1411,7 +1412,7 @@ pre.literal-block {
 
 .highlight {
     border-radius: .2rem;
-    width: 100%
+    width: 100%;
 }
 
 .highlight .gp,.highlight span.linenos {
@@ -2275,7 +2276,7 @@ ul.search li {
 
 /* HOVERXREF (TOOLTIP STYLES */
 .tooltipster-content {
-    background-color: var(--color-background-secondary);
+    background-color: var(--color-background-primary);
     color: var(--color-foreground-primary)!important;
 }
 
@@ -2295,4 +2296,8 @@ ul.search li {
 ::-webkit-scrollbar-thumb {
   background-color: var(--color-scroll-thumb);
   border-radius: 0.1rem;
+}
+
+.highlight {
+    background-color: var(--color-codeblock-background)!important;
 }

--- a/docs/_static/styles/furo.css
+++ b/docs/_static/styles/furo.css
@@ -2268,3 +2268,9 @@ ul.search li {
 .text-align\:right>p {
     text-align: right
 }
+
+/* HOVERXREF (TOOLTIP STYLES */
+.tooltipster-content {
+    background-color: var(--color-background-secondary);
+    color: var(--color-content-foreground);
+}

--- a/docs/_static/styles/furo.css
+++ b/docs/_static/styles/furo.css
@@ -74,7 +74,7 @@ body {
     --color-topic-title-background: rgba(20,184,166,.1);
     --icon-topic-default: var(--icon-pencil);
     --color-problematic: #b30000;
-    --color-foreground-primary: #000;
+    --color-foreground-primary: #1a1a1a;
     --color-foreground-secondary: #5a5c63;
     --color-foreground-muted: #646776;
     --color-foreground-border: #878787;
@@ -136,7 +136,9 @@ body {
     --color-link: var(--color-brand-content);
     --color-link--hover: var(--color-brand-content);
     --color-link-underline: var(--color-background-border);
-    --color-link-underline--hover: var(--color-foreground-border)
+    --color-link-underline--hover: var(--color-foreground-border);
+    --color-scroll-background: rgba(246, 246, 246, 0.8);
+    --color-scroll-thumb: #cecece;
 }
 
 .highlight {
@@ -470,7 +472,7 @@ html body .only-dark {
         --color-admonition-background: #18181a;
         --color-card-border: var(--color-background-secondary);
         --color-card-background: #18181a;
-        --color-card-marginals-background: var(--color-background-hover)
+        --color-card-marginals-background: var(--color-background-hover);
     }
 
     html body[data-theme=dark] .only-light {
@@ -505,7 +507,9 @@ html body .only-dark {
             --color-admonition-background: #18181a;
             --color-card-border: var(--color-background-secondary);
             --color-card-background: #18181a;
-            --color-card-marginals-background: var(--color-background-hover)
+            --color-card-marginals-background: var(--color-background-hover);
+            --color-scroll-background: #383838;
+            --color-scroll-thumb: #606060
         }
 
         html body:not([data-theme=light]) .only-light {
@@ -2272,5 +2276,23 @@ ul.search li {
 /* HOVERXREF (TOOLTIP STYLES */
 .tooltipster-content {
     background-color: var(--color-background-secondary);
-    color: var(--color-content-foreground);
+    color: var(--color-foreground-primary)!important;
+}
+
+.tooltipster-content > p {
+    color: var(--color-foreground-primary)!important;
+}
+
+/* Scrollbar Styles */
+::-webkit-scrollbar {
+  width: 0.8rem;
+}
+
+::-webkit-scrollbar-track {
+  background-color: var(--color-scroll-background);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--color-scroll-thumb);
+  border-radius: 0.1rem;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ hoverxref_role_types = {
 }
 
 hoverxref_roles = list(hoverxref_role_types.keys())
+hoverxref_domains = ['py']
 hoverxref_api_host = 'https://readthedocs.org'
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,8 @@ extensions = [
     "sphinxcontrib.asyncio",
     "sphinx.ext.intersphinx",
     "attributetable",
-    "sphinxext.opengraph"
+    "sphinxext.opengraph",
+    'hoverxref.extension'
 ]
 
 # OpenGraph Meta Tags
@@ -121,6 +122,12 @@ extlinks = {
     'wlissue': ('https://github.com/PythonistaGuild/Wavelink/issues/%s', 'GH-%s'),
     'ddocs': ('https://discord.com/developers/docs/%s', None),
 }
+
+
+# Hoverxref Settings...
+hoverxref_auto_ref = True
+hoverxref_intersphinx = ['https://docs.python.org/3', 'https://discordpy.readthedocs.io/en/stable/']
+
 
 pygments_style = "sphinx"
 pygments_dark_style = "monokai"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,11 +137,12 @@ hoverxref_role_types = {
     'attr': 'tooltip',
     'func': 'tooltip',
     'meth': 'tooltip',
-    'internal': 'tooltip'
+    'exc': 'tooltip'
 }
 
 hoverxref_roles = list(hoverxref_role_types.keys())
-
+hoverxref_domains = ['py']
+hoverxref_default_type = 'tooltip'
 
 pygments_style = "sphinx"
 pygments_dark_style = "monokai"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,12 +137,10 @@ hoverxref_role_types = {
     'attr': 'tooltip',
     'func': 'tooltip',
     'meth': 'tooltip',
-    'exception': 'tooltip'
+    'internal': 'tooltip'
 }
 
 hoverxref_roles = list(hoverxref_role_types.keys())
-hoverxref_domains = ['py']
-hoverxref_api_host = 'https://readthedocs.org'
 
 
 pygments_style = "sphinx"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ extlinks = {
 
 # Hoverxref Settings...
 hoverxref_auto_ref = True
-hoverxref_intersphinx = ['https://docs.python.org/3', 'https://discordpy.readthedocs.io/en/stable/']
+hoverxref_intersphinx = ['py', 'dpy']
 
 hoverxref_role_types = {
     'hoverxref': 'modal',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,15 +130,17 @@ hoverxref_intersphinx = ['https://docs.python.org/3', 'https://discordpy.readthe
 
 hoverxref_role_types = {
     'hoverxref': 'modal',
-    'ref': 'modal',  # for hoverxref_auto_ref config
-    'confval': 'tooltip',  # for custom object
-    'mod': 'tooltip',  # for Python Sphinx Domain
-    'class': 'tooltip',  # for Python Sphinx Domain
+    'ref': 'modal',
+    'confval': 'tooltip',
+    'mod': 'tooltip',
+    'class': 'tooltip',
     'attr': 'tooltip',
     'func': 'tooltip',
     'meth': 'tooltip',
     'exception': 'tooltip'
 }
+
+hoverxref_roles = ['hoverxref', 'ref', 'confval', 'mod', 'class', 'attr', 'func', 'meth', 'exception']
 
 
 pygments_style = "sphinx"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,18 @@ extlinks = {
 hoverxref_auto_ref = True
 hoverxref_intersphinx = ['https://docs.python.org/3', 'https://discordpy.readthedocs.io/en/stable/']
 
+hoverxref_role_types = {
+    'hoverxref': 'modal',
+    'ref': 'modal',  # for hoverxref_auto_ref config
+    'confval': 'tooltip',  # for custom object
+    'mod': 'tooltip',  # for Python Sphinx Domain
+    'class': 'tooltip',  # for Python Sphinx Domain
+    'attr': 'tooltip',
+    'func': 'tooltip',
+    'meth': 'tooltip',
+    'exception': 'tooltip'
+}
+
 
 pygments_style = "sphinx"
 pygments_dark_style = "monokai"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,8 @@ hoverxref_role_types = {
     'exception': 'tooltip'
 }
 
-hoverxref_roles = ['hoverxref', 'ref', 'confval', 'mod', 'class', 'attr', 'func', 'meth', 'exception']
+hoverxref_roles = list(hoverxref_role_types.keys())
+hoverxref_api_host = 'https://readthedocs.org'
 
 
 pygments_style = "sphinx"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,6 +143,8 @@ hoverxref_role_types = {
 hoverxref_roles = list(hoverxref_role_types.keys())
 hoverxref_domains = ['py']
 hoverxref_default_type = 'tooltip'
+hoverxref_tooltip_theme = ['tooltipster-punk', 'tooltipster-shadow', 'tooltipster-shadow-custom']
+
 
 pygments_style = "sphinx"
 pygments_dark_style = "monokai"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ Pygments
 furo
 discord.py>=2.0.1
 sphinxext-opengraph
+sphinx-hoverxref

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Wavelink"
-version = "2.6.0b1"
+version = "2.6.0b2"
 authors = [
   { name="EvieePy", email="evieepy@gmail.com" },
 ]

--- a/wavelink/__init__.py
+++ b/wavelink/__init__.py
@@ -25,7 +25,7 @@ __title__ = "WaveLink"
 __author__ = "PythonistaGuild, EvieePy"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019-Present (c) PythonistaGuild, EvieePy"
-__version__ = "2.6.0b1"
+__version__ = "2.6.0b2"
 
 from .enums import *
 from .exceptions import *

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -203,7 +203,8 @@ class Websocket:
                                      f'Disregarding.')
                         continue
 
-                    await player._destroy()
+                    if self.node._invalidated.get(player.guild.id):
+                        await player._destroy()
 
                     logger.debug(f'Node {self.node} websocket acknowledged "WebsocketClosedEvent": '
                                  f'<code: {data["code"]}, reason: {data["reason"]}, by_discord: {data["byRemote"]}>. '


### PR DESCRIPTION
Update some of the docs styling to be more visually appealing.
Added hoverxref to docs for referencing sphinx roles without having to click through to them. This also works between wavelink and discord.py/python docs.

Bump version.