### PR TITLE
add explicit attribute to SpotifyTrack 

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -200,7 +200,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
         self.isrc: str | None = data.get("external_ids", {}).get('irsc')
-        self.explicit: bool = data.get('explicit', False)
+        self.explicit: bool = True if data.get('explicit', False) == "true" or data.get('explicit', False) else False
 
     def __str__(self) -> str:
         return f'{self.name} - {self.artists[0]}'

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -200,7 +200,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
         self.isrc: str | None = data.get("external_ids", {}).get('irsc')
-        self.explicit: bool = True if data.get('explicit', False) == "true" or data.get('explicit', False) else False
+        self.explicit: bool = True if data.get('explicit', False) == "true" or data.get('explicit', False) == True else False
 
     def __str__(self) -> str:
         return f'{self.name} - {self.artists[0]}'

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -200,7 +200,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
         self.isrc: str | None = data.get("external_ids", {}).get('irsc')
-        self.explicit: bool = True if data.get('explicit', False) == "true" or data.get('explicit', False) == True else False
+        self.explicit: bool = data.get('explicit', False) in {"true", True}
 
     def __str__(self) -> str:
         return f'{self.name} - {self.artists[0]}'

--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -162,6 +162,8 @@ class SpotifyTrack:
         The track length in milliseconds.
     duration: int
         Alias to length.
+    explicit: bool
+        Whether this track is explicit or not.
     """
 
     __slots__ = (
@@ -175,6 +177,7 @@ class SpotifyTrack:
         'id',
         'length',
         'duration',
+        'explicit',
         'isrc',
         '__dict__'
     )
@@ -197,6 +200,7 @@ class SpotifyTrack:
         self.length: int = data['duration_ms']
         self.duration: int = self.length
         self.isrc: str | None = data.get("external_ids", {}).get('irsc')
+        self.explicit: bool = data.get('explicit', False)
 
     def __str__(self) -> str:
         return f'{self.name} - {self.artists[0]}'


### PR DESCRIPTION
See #90

Added explicit attribute to `SpotifyTrack` class.

It is part of the Spotify `https://api.spotify.com/v1/tracks` response

Now you can just do:
```py
if track.explicit == True:
  # track has explicit content
```