### PR TITLE
Add type hint for method in `SpotifyAsyncIterator`.

### DIFF
--- a/wavelink/ext/spotify/__init__.py
+++ b/wavelink/ext/spotify/__init__.py
@@ -79,7 +79,7 @@ class SpotifyAsyncIterator:
         for track in tracks:
             await self._queue.put(track)
 
-    async def __anext__(self):
+    async def __anext__(self) -> SpotifyTrack:
         if self._first:
             await self.fill_queue()
             self._first = False


### PR DESCRIPTION
Added type hint to `SpotifyAsyncIterator.__anext__()` for yield value.
Based on discussion in #239.