### PR TITLE
Clean up some typing syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,3 @@ ignore = ["test*.py", "examples/*.py", "docs/*"]
 pythonVersion = "3.10"
 typeCheckingMode = "strict"
 reportPrivateUsage = false
-reportPropertyTypeMismatch = "warning"
-reportUnnecessaryTypeIgnoreComment = "warning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,75 @@ line-length = 120
 [tool.isort]
 profile = "black"
 
+[tool.ruff]
+# Credit to @mikeshardmind for most of this setup.
+include = ["wavelink"]
+line-length = 120
+target-version = "py310"
+select = [
+    "F",
+    "E",
+    "I",
+    "UP",
+    "YTT",
+    "ANN",
+    "S",
+    "BLE",
+    "B",
+    "A",
+    "COM",
+    "C4",
+    "DTZ",
+    "EM",
+    "ISC",
+    "G",
+    "INP",
+    "PIE",
+    "T20",
+    "Q003",
+    "RSE",
+    "RET",
+    "SIM",
+    "TID",
+    "PTH",
+    "ERA",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    "TRY",
+    "RUF",
+]
+ignore = [
+    "G002",    # Erroneous issue with %-logging when logging can be configured for % logging.
+    "S101",    # Use of assert here is a known quantity. Blame typing memes.
+    "PLR2004", # Magic value comparison. May remove later.
+    "SIM105",  # Suppressable exception. I'm not paying the overhead of contextlib.suppress for stylistic choices.
+    "C90",     # McCabe complexity memes.
+    "ANN204",  # Special method return types.
+    "S311",    # No need for cryptographically secure random number generation in this use case.
+    "ANN101",  # Type of self is implicit.
+    "ANN102",  # Type of cls is implicit.
+    # "ANN401",  # Not sure how else to type *args and **kwargs when they could be anything.
+    "PLR0913", # Too many parameters in a function definition doesn't matter.
+    "A001",    # Shadowing some builtin names.
+    "A002",    # See above.
+    "A003",    # See above.
+    "NPY",     # Numpy isn't relevant in this project.
+    "PD",      # Pandas isn't relevant in this project
+]
+unfixable = [
+    "ERA", # I don't want anything erroneously detected deleted by this.
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F403", "PLC0414"] # Importing internal modules usually throws these.
+
 [tool.pyright]
-exclude = ["venv"]
 ignore = ["test*.py", "examples/*.py", "docs/*"]
+pythonVersion = "3.10"
 typeCheckingMode = "strict"
 reportPrivateUsage = false
+reportImportCycles = "warning"
+reportPropertyTypeMismatch = "warning"
+reportUnnecessaryTypeIgnoreComment = "warning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,75 +43,10 @@ line-length = 120
 [tool.isort]
 profile = "black"
 
-[tool.ruff]
-# Credit to @mikeshardmind for most of this setup.
-include = ["wavelink"]
-line-length = 120
-target-version = "py310"
-select = [
-    "F",
-    "E",
-    "I",
-    "UP",
-    "YTT",
-    "ANN",
-    "S",
-    "BLE",
-    "B",
-    "A",
-    "COM",
-    "C4",
-    "DTZ",
-    "EM",
-    "ISC",
-    "G",
-    "INP",
-    "PIE",
-    "T20",
-    "Q003",
-    "RSE",
-    "RET",
-    "SIM",
-    "TID",
-    "PTH",
-    "ERA",
-    "PLC",
-    "PLE",
-    "PLR",
-    "PLW",
-    "TRY",
-    "RUF",
-]
-ignore = [
-    "G002",    # Erroneous issue with %-logging when logging can be configured for % logging.
-    "S101",    # Use of assert here is a known quantity. Blame typing memes.
-    "PLR2004", # Magic value comparison. May remove later.
-    "SIM105",  # Suppressable exception. I'm not paying the overhead of contextlib.suppress for stylistic choices.
-    "C90",     # McCabe complexity memes.
-    "ANN204",  # Special method return types.
-    "S311",    # No need for cryptographically secure random number generation in this use case.
-    "ANN101",  # Type of self is implicit.
-    "ANN102",  # Type of cls is implicit.
-    # "ANN401",  # Not sure how else to type *args and **kwargs when they could be anything.
-    "PLR0913", # Too many parameters in a function definition doesn't matter.
-    "A001",    # Shadowing some builtin names.
-    "A002",    # See above.
-    "A003",    # See above.
-    "NPY",     # Numpy isn't relevant in this project.
-    "PD",      # Pandas isn't relevant in this project
-]
-unfixable = [
-    "ERA", # I don't want anything erroneously detected deleted by this.
-]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F403", "PLC0414"] # Importing internal modules usually throws these.
-
 [tool.pyright]
 ignore = ["test*.py", "examples/*.py", "docs/*"]
 pythonVersion = "3.10"
 typeCheckingMode = "strict"
 reportPrivateUsage = false
-reportImportCycles = "warning"
 reportPropertyTypeMismatch = "warning"
 reportUnnecessaryTypeIgnoreComment = "warning"

--- a/wavelink/backoff.py
+++ b/wavelink/backoff.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 
 class Backoff:
     """An implementation of an Exponential Backoff.
+
     Parameters
     ----------
     base: int

--- a/wavelink/filters.py
+++ b/wavelink/filters.py
@@ -26,18 +26,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
-    from types.filters import ChannelMix as ChannelMixPayload
-    from types.filters import Distortion as DistortionPayload
-    from types.filters import Equalizer as EqualizerPayload
-    from types.filters import FilterPayload
-    from types.filters import Karaoke as KaraokePayload
-    from types.filters import LowPass as LowPassPayload
-    from types.filters import Rotation as RotationPayload
-    from types.filters import Timescale as TimescalePayload
-    from types.filters import Tremolo as TremoloPayload
-    from types.filters import Vibrato as VibratoPayload
-
     from typing_extensions import Self, Unpack
+
+    from .types.filters import ChannelMix as ChannelMixPayload
+    from .types.filters import Distortion as DistortionPayload
+    from .types.filters import Equalizer as EqualizerPayload
+    from .types.filters import FilterPayload
+    from .types.filters import Karaoke as KaraokePayload
+    from .types.filters import LowPass as LowPassPayload
+    from .types.filters import Rotation as RotationPayload
+    from .types.filters import Timescale as TimescalePayload
+    from .types.filters import Tremolo as TremoloPayload
+    from .types.filters import Vibrato as VibratoPayload
 
 
 __all__ = (

--- a/wavelink/filters.py
+++ b/wavelink/filters.py
@@ -23,7 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from types.filters import ChannelMix as ChannelMixPayload
@@ -36,7 +36,8 @@ if TYPE_CHECKING:
     from types.filters import Timescale as TimescalePayload
     from types.filters import Tremolo as TremoloPayload
     from types.filters import Vibrato as VibratoPayload
-    from typing import Self, Unpack
+
+    from typing_extensions import Self, Unpack
 
 
 __all__ = (
@@ -69,36 +70,36 @@ class FiltersOptions(TypedDict, total=False):
 
 
 class EqualizerOptions(TypedDict):
-    bands: Optional[list[EqualizerPayload]]
+    bands: list[EqualizerPayload] | None
 
 
 class KaraokeOptions(TypedDict):
-    level: Optional[float]
-    mono_level: Optional[float]
-    filter_band: Optional[float]
-    filter_width: Optional[float]
+    level: float | None
+    mono_level: float | None
+    filter_band: float | None
+    filter_width: float | None
 
 
 class RotationOptions(TypedDict):
-    rotation_hz: Optional[float]
+    rotation_hz: float | None
 
 
 class DistortionOptions(TypedDict):
-    sin_offset: Optional[float]
-    sin_scale: Optional[float]
-    cos_offset: Optional[float]
-    cos_scale: Optional[float]
-    tan_offset: Optional[float]
-    tan_scale: Optional[float]
-    offset: Optional[float]
-    scale: Optional[float]
+    sin_offset: float | None
+    sin_scale: float | None
+    cos_offset: float | None
+    cos_scale: float | None
+    tan_offset: float | None
+    tan_scale: float | None
+    offset: float | None
+    scale: float | None
 
 
 class ChannelMixOptions(TypedDict):
-    left_to_left: Optional[float]
-    left_to_right: Optional[float]
-    right_to_left: Optional[float]
-    right_to_right: Optional[float]
+    left_to_left: float | None
+    left_to_right: float | None
+    right_to_left: float | None
+    right_to_right: float | None
 
 
 class Equalizer:

--- a/wavelink/lfu.py
+++ b/wavelink/lfu.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, DefaultDict
+from typing import Any
 
 from .exceptions import WavelinkException
 
@@ -81,7 +81,7 @@ class LFUCache:
         self._capacity = capacity
         self._cache: dict[Any, DataNode] = {}
 
-        self._freq_map: DefaultDict[int, DLL] = defaultdict(DLL)
+        self._freq_map: defaultdict[int, DLL] = defaultdict(DLL)
         self._min: int = 1
         self._used: int = 0
 

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import logging
 import secrets
 import urllib
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Union, cast
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 import aiohttp
 import discord

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -27,7 +27,7 @@ import logging
 import secrets
 import urllib.parse
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import aiohttp
 import discord
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     )
     from .types.tracks import TrackPayload
 
-    LoadedResponse = (
+    LoadedResponse: TypeAlias = (
         TrackLoadedResponse | SearchLoadedResponse | PlaylistLoadedResponse | EmptyLoadedResponse | ErrorLoadedResponse
     )
 

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -25,9 +25,9 @@ from __future__ import annotations
 
 import logging
 import secrets
-import urllib
+import urllib.parse
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal
 
 import aiohttp
 import discord
@@ -64,9 +64,9 @@ if TYPE_CHECKING:
     )
     from .types.tracks import TrackPayload
 
-    LoadedResponse = Union[
-        TrackLoadedResponse, SearchLoadedResponse, PlaylistLoadedResponse, EmptyLoadedResponse, ErrorLoadedResponse
-    ]
+    LoadedResponse = (
+        TrackLoadedResponse | SearchLoadedResponse | PlaylistLoadedResponse | EmptyLoadedResponse | ErrorLoadedResponse
+    )
 
 
 __all__ = ("Node", "Pool")
@@ -699,7 +699,7 @@ class Pool:
             This method no longer accepts the ``cls`` parameter.
         """
         # TODO: Documentation Extension for `.. positional-only::` marker.
-        encoded_query: str = cast(str, urllib.parse.quote(query))  # type: ignore
+        encoded_query: str = urllib.parse.quote(query)
 
         if cls.__cache is not None:
             potential: list[Playable] | Playlist = cls.__cache.get(encoded_query, None)

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -27,9 +27,8 @@ import asyncio
 import logging
 import random
 import time
-import typing
 from collections import deque
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import async_timeout
 import discord
@@ -66,7 +65,7 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-T_a: typing.TypeAlias = "list[Playable] | Playlist"
+T_a: TypeAlias = list[Playable] | Playlist
 
 
 class Player(discord.VoiceProtocol):

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -29,7 +29,7 @@ import random
 import time
 import typing
 from collections import deque
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import async_timeout
 import discord
@@ -46,7 +46,7 @@ from .exceptions import (
     LavalinkLoadException,
     QueueEmpty,
 )
-from .filters import *
+from .filters import Filters
 from .node import Pool
 from .payloads import PlayerUpdateEventPayload, TrackEndEventPayload
 from .queue import Queue
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from .types.request import Request as RequestPayload
     from .types.state import PlayerVoiceState, VoiceState
 
-    VocalGuildChannel = Union[discord.VoiceChannel, discord.StageChannel]
+    VocalGuildChannel = discord.VoiceChannel | discord.StageChannel
 
 logger: logging.Logger = logging.getLogger(__name__)
 

--- a/wavelink/queue.py
+++ b/wavelink/queue.py
@@ -26,11 +26,12 @@ from __future__ import annotations
 import asyncio
 import random
 from collections import deque
-from typing import Any, Iterator, overload
+from collections.abc import Iterator
+from typing import overload
 
 from .enums import QueueMode
 from .exceptions import QueueEmpty
-from .tracks import *
+from .tracks import Playable, Playlist
 
 __all__ = ("Queue",)
 
@@ -71,11 +72,11 @@ class _Queue:
     def __iter__(self) -> Iterator[Playable]:
         return self._queue.__iter__()
 
-    def __contains__(self, item: Any) -> bool:
+    def __contains__(self, item: object) -> bool:
         return item in self._queue
 
     @staticmethod
-    def _check_compatability(item: Any) -> None:
+    def _check_compatability(item: object) -> None:
         if not isinstance(item, Playable):
             raise TypeError("This queue is restricted to Playable objects.")
 
@@ -308,7 +309,7 @@ class Queue(_Queue):
         added: int = 0
 
         async with self._lock:
-            if isinstance(item, (list, Playlist)):
+            if isinstance(item, list | Playlist):
                 if atomic:
                     super()._check_atomic(item)
 
@@ -394,7 +395,7 @@ class Queue(_Queue):
         return self._mode
 
     @mode.setter
-    def mode(self, value: QueueMode):
+    def mode(self, value: QueueMode) -> None:
         if not hasattr(self, "_mode"):
             raise AttributeError("This queues mode can not be set.")
 

--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -23,7 +23,8 @@ SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterator, TypeAlias, overload
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 import yarl
 
@@ -482,7 +483,7 @@ class Playlist:
     def pop(self, index: int = -1) -> Playable:
         return self.tracks.pop(index)
 
-    def track_extras(self, **attrs: Any) -> None:
+    def track_extras(self, **attrs: object) -> None:
         """Method which sets attributes to all :class:`Playable` in this playlist, with the provided keyword arguments.
 
         This is useful when you need to attach state to your :class:`Playable`, E.g. create a requester attribute.

--- a/wavelink/types/filters.py
+++ b/wavelink/types/filters.py
@@ -21,10 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from typing import TYPE_CHECKING, Any, Optional, TypedDict
-
-if TYPE_CHECKING:
-    from typing_extensions import NotRequired
+from typing import Any, TypedDict
 
 
 class Equalizer(TypedDict):
@@ -32,64 +29,64 @@ class Equalizer(TypedDict):
     gain: float
 
 
-class Karaoke(TypedDict):
-    level: NotRequired[Optional[float]]
-    monoLevel: NotRequired[Optional[float]]
-    filterBand: NotRequired[Optional[float]]
-    filterWidth: NotRequired[Optional[float]]
+class Karaoke(TypedDict, total=False):
+    level: float | None
+    monoLevel: float | None
+    filterBand: float | None
+    filterWidth: float | None
 
 
-class Timescale(TypedDict):
-    speed: NotRequired[Optional[float]]
-    pitch: NotRequired[Optional[float]]
-    rate: NotRequired[Optional[float]]
+class Timescale(TypedDict, total=False):
+    speed: float | None
+    pitch: float | None
+    rate: float | None
 
 
-class Tremolo(TypedDict):
-    frequency: NotRequired[Optional[float]]
-    depth: NotRequired[Optional[float]]
+class Tremolo(TypedDict, total=False):
+    frequency: float | None
+    depth: float | None
 
 
-class Vibrato(TypedDict):
-    frequency: NotRequired[Optional[float]]
-    depth: NotRequired[Optional[float]]
+class Vibrato(TypedDict, total=False):
+    frequency: float | None
+    depth: float | None
 
 
-class Rotation(TypedDict):
-    rotationHz: NotRequired[Optional[float]]
+class Rotation(TypedDict, total=False):
+    rotationHz: float | None
 
 
-class Distortion(TypedDict):
-    sinOffset: NotRequired[Optional[float]]
-    sinScale: NotRequired[Optional[float]]
-    cosOffset: NotRequired[Optional[float]]
-    cosScale: NotRequired[Optional[float]]
-    tanOffset: NotRequired[Optional[float]]
-    tanScale: NotRequired[Optional[float]]
-    offset: NotRequired[Optional[float]]
-    scale: NotRequired[Optional[float]]
+class Distortion(TypedDict, total=False):
+    sinOffset: float | None
+    sinScale: float | None
+    cosOffset: float | None
+    cosScale: float | None
+    tanOffset: float | None
+    tanScale: float | None
+    offset: float | None
+    scale: float | None
 
 
-class ChannelMix(TypedDict):
-    leftToLeft: NotRequired[Optional[float]]
-    leftToRight: NotRequired[Optional[float]]
-    rightToLeft: NotRequired[Optional[float]]
-    rightToRight: NotRequired[Optional[float]]
+class ChannelMix(TypedDict, total=False):
+    leftToLeft: float | None
+    leftToRight: float | None
+    rightToLeft: float | None
+    rightToRight: float | None
 
 
-class LowPass(TypedDict):
-    smoothing: NotRequired[Optional[float]]
+class LowPass(TypedDict, total=False):
+    smoothing: float | None
 
 
-class FilterPayload(TypedDict):
-    volume: NotRequired[Optional[float]]
-    equalizer: NotRequired[Optional[list[Equalizer]]]
-    karaoke: NotRequired[Karaoke]
-    timescale: NotRequired[Timescale]
-    tremolo: NotRequired[Tremolo]
-    vibrato: NotRequired[Vibrato]
-    rotation: NotRequired[Rotation]
-    distortion: NotRequired[Distortion]
-    channelMix: NotRequired[ChannelMix]
-    lowPass: NotRequired[LowPass]
-    pluginFilters: NotRequired[dict[str, Any]]
+class FilterPayload(TypedDict, total=False):
+    volume: float | None
+    equalizer: list[Equalizer] | None
+    karaoke: Karaoke
+    timescale: Timescale
+    tremolo: Tremolo
+    vibrato: Vibrato
+    rotation: Rotation
+    distortion: Distortion
+    channelMix: ChannelMix
+    lowPass: LowPass
+    pluginFilters: dict[str, Any]

--- a/wavelink/types/request.py
+++ b/wavelink/types/request.py
@@ -23,24 +23,24 @@ SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
-    from typing_extensions import NotRequired, TypeAlias
+    from typing_extensions import NotRequired
 
     from .filters import FilterPayload
 
 
 class VoiceRequest(TypedDict):
     token: str
-    endpoint: Optional[str]
+    endpoint: str | None
     sessionId: str
 
 
 class _BaseRequest(TypedDict, total=False):
     voice: VoiceRequest
     position: int
-    endTime: Optional[int]
+    endTime: int | None
     volume: int
     paused: bool
     filters: FilterPayload
@@ -59,4 +59,4 @@ class UpdateSessionRequest(TypedDict):
     timeout: NotRequired[int]
 
 
-Request: TypeAlias = "_BaseRequest | EncodedTrackRequest | IdentifierRequest"
+Request: TypeAlias = _BaseRequest | EncodedTrackRequest | IdentifierRequest

--- a/wavelink/types/state.py
+++ b/wavelink/types/state.py
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
@@ -36,7 +36,7 @@ class PlayerState(TypedDict):
 
 class VoiceState(TypedDict, total=False):
     token: str
-    endpoint: Optional[str]
+    endpoint: str | None
     session_id: str
 
 

--- a/wavelink/types/websocket.py
+++ b/wavelink/types/websocket.py
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from typing import TYPE_CHECKING, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
@@ -99,13 +99,13 @@ class WebsocketClosedEvent(TypedDict):
     byRemote: bool
 
 
-WebsocketOP = Union[
-    ReadyOP,
-    PlayerUpdateOP,
-    StatsOP,
-    TrackStartEvent,
-    TrackEndEvent,
-    TrackExceptionEvent,
-    TrackStuckEvent,
-    WebsocketClosedEvent,
-]
+WebsocketOP = (
+    ReadyOP
+    | PlayerUpdateOP
+    | StatsOP
+    | TrackStartEvent
+    | TrackEndEvent
+    | TrackExceptionEvent
+    | TrackStuckEvent
+    | WebsocketClosedEvent
+)

--- a/wavelink/types/websocket.py
+++ b/wavelink/types/websocket.py
@@ -21,7 +21,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from typing import TYPE_CHECKING, Literal, TypedDict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
@@ -99,7 +101,7 @@ class WebsocketClosedEvent(TypedDict):
     byRemote: bool
 
 
-WebsocketOP = (
+WebsocketOP: TypeAlias = (
     ReadyOP
     | PlayerUpdateOP
     | StatsOP


### PR DESCRIPTION
Ideally, this doesn't result in any change to the functionality; it's more about making the typing syntax consistent with python 3.10+ and ensuring pyright flags it accordingly if it isn't.