### PR TITLE
Add extras for userData in Lavalink

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -85,6 +85,7 @@ Added
 - :meth:`wavelink.Node.fetch_version`
 - :meth:`wavelink.Node.fetch_player_info`
 - :meth:`wavelink.Node.fetch_players`
+- :attr:`wavelink.Playable.extras`
 
 
 Connecting

--- a/docs/wavelink.rst
+++ b/docs/wavelink.rst
@@ -347,6 +347,15 @@ Filters
     :members:
 
 
+Utils
+-----
+
+.. attributetable:: ExtrasNamespace
+
+.. autoclass:: ExtrasNamespace
+
+    
+
 Exceptions
 ----------
 

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -667,7 +667,7 @@ class Player(discord.VoiceProtocol):
             self._filters = filters
 
         request: RequestPayload = {
-            "encodedTrack": track.encoded,
+            "track": {"encoded": track.encoded, "userData": dict(track.extras)},
             "volume": vol,
             "position": start,
             "endTime": end,
@@ -850,7 +850,7 @@ class Player(discord.VoiceProtocol):
         if force:
             self.queue._loaded = None
 
-        request: RequestPayload = {"encodedTrack": None}
+        request: RequestPayload = {"track": {"encoded": None}}
         await self.node._update_player(self.guild.id, data=request, replace=True)
 
         return old

--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -31,6 +31,7 @@ import yarl
 import wavelink
 
 from .enums import TrackSource
+from .utils import ExtrasNamespace
 
 if TYPE_CHECKING:
     from .types.tracks import (
@@ -133,6 +134,8 @@ class Playable:
 
         self._playlist = playlist
         self._recommended: bool = False
+
+        self._extras: ExtrasNamespace = ExtrasNamespace(data.get("userData", {}))
 
     def __hash__(self) -> int:
         return hash(self.encoded)
@@ -246,6 +249,50 @@ class Playable:
     def recommended(self) -> bool:
         """Property returning a bool indicating whether this track was recommended via AutoPlay."""
         return self._recommended
+
+    @property
+    def extras(self) -> ExtrasNamespace:
+        """Property returning a :class:`~wavelink.ExtrasNamespace` of extras for this :class:`Playable`.
+
+        You can set this property with a :class:`dict` of valid :class:`str` keys to any valid ``JSON`` value,
+        or a :class:`~wavelink.ExtrasNamespace`.
+
+        If a dict is passed, it will be converted into an :class:`~wavelink.ExtrasNamespace`,
+        which can be converted back to a dict with dict(...). Additionally, you can also use list or tuple on
+        :class:`~wavelink.ExtrasNamespace`.
+
+        The extras dict will be sent to Lavalink as the ``userData`` field.
+
+
+        .. warning::
+
+            This is only available when using Lavalink 4+ (**Non BETA**) versions.
+
+
+        Examples
+        --------
+
+            .. code:: python
+
+                track: wavelink.Playable = wavelink.Playable.search("QUERY")
+                track.extras = {"requester_id": 1234567890}
+
+                # later...
+                print(track.extras.requester_id)
+                # or
+                print(dict(track.extras)["requester_id"])
+
+
+        .. versionadded:: 3.1.0
+        """
+        return self._extras
+
+    @extras.setter
+    def extras(self, __value: ExtrasNamespace | dict[str, Any]) -> None:
+        if isinstance(__value, ExtrasNamespace):
+            self._extras = __value
+        else:
+            self._extras = ExtrasNamespace(__value)
 
     @classmethod
     async def search(cls, query: str, /, *, source: TrackSource | str | None = TrackSource.YouTubeMusic) -> Search:

--- a/wavelink/types/request.py
+++ b/wavelink/types/request.py
@@ -23,7 +23,7 @@ SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 
 if TYPE_CHECKING:
     from typing_extensions import NotRequired
@@ -37,6 +37,12 @@ class VoiceRequest(TypedDict):
     sessionId: str
 
 
+class TrackRequest(TypedDict, total=False):
+    encoded: str | None
+    identifier: str
+    userData: dict[str, Any]
+
+
 class _BaseRequest(TypedDict, total=False):
     voice: VoiceRequest
     position: int
@@ -44,6 +50,7 @@ class _BaseRequest(TypedDict, total=False):
     volume: int
     paused: bool
     filters: FilterPayload
+    track: TrackRequest
 
 
 class EncodedTrackRequest(_BaseRequest):

--- a/wavelink/types/tracks.py
+++ b/wavelink/types/tracks.py
@@ -50,6 +50,7 @@ class TrackPayload(TypedDict):
     encoded: str
     info: TrackInfoPayload
     pluginInfo: dict[Any, Any]
+    userData: dict[str, Any]
 
 
 class PlaylistPayload(TypedDict):

--- a/wavelink/utils.py
+++ b/wavelink/utils.py
@@ -1,7 +1,7 @@
 """
 MIT License
 
-Copyright (c) 2019-Present PythonistaGuild
+Copyright (c) 2019-Current PythonistaGuild, EvieePy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -21,21 +21,42 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-__title__ = "WaveLink"
-__author__ = "PythonistaGuild, EvieePy"
-__license__ = "MIT"
-__copyright__ = "Copyright 2019-Present (c) PythonistaGuild, EvieePy"
-__version__ = "3.1.0"
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+__all__ = (
+    "Namespace",
+    "ExtrasNamespace",
+)
 
 
-from .enums import *
-from .exceptions import *
-from .filters import *
-from .lfu import CapacityZero as CapacityZero
-from .lfu import LFUCache as LFUCache
-from .node import *
-from .payloads import *
-from .player import Player as Player
-from .queue import *
-from .tracks import *
-from .utils import ExtrasNamespace as ExtrasNamespace
+class Namespace(SimpleNamespace):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
+        return iter(self.__dict__.items())
+
+
+class ExtrasNamespace(Namespace):
+    """A subclass of :class:`types.SimpleNameSpace`.
+
+    You can construct this namespace with a :class:`dict` of `str` keys and `Any` value, or with keyword pairs or
+    with a mix of both.
+
+    You can access a dict version of this namespace by calling `dict()` on an instance.
+
+
+    Examples
+    --------
+
+        .. code:: python
+
+            ns: ExtrasNamespace = ExtrasNamespace({"hello": "world!"}, stuff=1)
+
+            # Later...
+            print(ns.hello)
+            print(ns.stuff)
+            print(dict(ns))
+    """
+
+    def __init__(self, __dict: dict[str, Any] = {}, /, **kwargs: Any) -> None:
+        updated = __dict | kwargs
+        super().__init__(**updated)


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

This adds extras to Playable for passing and accessing the `userData` field from Lavalink.
This PR implements a new class `ExtrasNamespace` which is just a small alteration of `types.SimpleNamespace`.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
