### PR TITLE
Add extra_event for unknown plugin events

### DIFF
--- a/docs/migrating.rst
+++ b/docs/migrating.rst
@@ -86,6 +86,7 @@ Added
 - :meth:`wavelink.Node.fetch_player_info`
 - :meth:`wavelink.Node.fetch_players`
 - :attr:`wavelink.Playable.extras`
+- :func:`wavelink.on_wavelink_extra_event`
 
 
 Connecting

--- a/docs/wavelink.rst
+++ b/docs/wavelink.rst
@@ -77,6 +77,15 @@ An event listener in a cog.
     Called when a node has been closed and cleaned-up. The second parameter ``disconnected`` is a list of
     :class:`wavelink.Player` that were connected on this Node and are now disconnected.
 
+.. function:: on_wavelink_extra_event(payload: wavelink.ExtraEventPayload)
+
+    Called when an ``Unknown`` and/or ``Unhandled`` event is recevied via Lavalink. This is most likely due to
+    a plugin like SponsorBlock sending custom event data. The payload includes the raw data sent from Lavalink.
+
+    .. note::
+
+        Please see the documentation for your Lavalink plugins to determine what data they send.
+
 
 Types
 -----
@@ -188,6 +197,11 @@ Payloads
 .. attributetable:: InfoResponsePayload
 
 .. autoclass:: InfoResponsePayload
+    :members:
+
+.. attributetable:: ExtraEventPayload
+
+.. autoclass:: ExtraEventPayload
     :members:
 
 

--- a/docs/wavelink.rst
+++ b/docs/wavelink.rst
@@ -85,6 +85,9 @@ An event listener in a cog.
     .. note::
 
         Please see the documentation for your Lavalink plugins to determine what data they send.
+    
+
+    .. versionadded:: 3.1.0
 
 
 Types

--- a/wavelink/payloads.py
+++ b/wavelink/payloads.py
@@ -62,6 +62,7 @@ __all__ = (
     "PlayerStatePayload",
     "VoiceStatePayload",
     "PlayerResponsePayload",
+    "ExtraEventPayload",
 )
 
 
@@ -520,3 +521,30 @@ class InfoResponsePayload:
         self.source_managers: list[str] = data["sourceManagers"]
         self.filters: list[str] = data["filters"]
         self.plugins: list[PluginResponsePayload] = [PluginResponsePayload(p) for p in data["plugins"]]
+
+
+class ExtraEventPayload:
+    """Payload received in the :func:`on_wavelink_extra_event` event.
+
+    This payload is created when an ``Unknown`` and ``Unhandled`` event is received from Lavalink, most likely via
+    a plugin.
+
+    .. note::
+
+        See the appropriate documentation of the plugin for the data sent with these events.
+
+
+    Attributes
+    ----------
+    node: :class:`~wavelink.Node`
+        The node that the event pertains to.
+    player: :class:`~wavelink.Player` | None
+        The player associated with this event. Could be None.
+    data: dict[str, Any]
+        The raw data sent from Lavalink for this event.
+    """
+
+    def __init__(self, *, node: Node, player: Player | None, data: dict[str, Any]) -> None:
+        self.node = node
+        self.player = player
+        self.data = data

--- a/wavelink/payloads.py
+++ b/wavelink/payloads.py
@@ -542,6 +542,9 @@ class ExtraEventPayload:
         The player associated with this event. Could be None.
     data: dict[str, Any]
         The raw data sent from Lavalink for this event.
+
+
+    .. versionadded:: 3.1.0
     """
 
     def __init__(self, *, node: Node, player: Player | None, data: dict[str, Any]) -> None:

--- a/wavelink/websocket.py
+++ b/wavelink/websocket.py
@@ -239,7 +239,8 @@ class Websocket:
                     self.dispatch("websocket_closed", wcpayload)
 
                 else:
-                    logger.debug(f"Received unknown event type from Lavalink '{data['type']}'. Disregarding.")
+                    other_payload: ExtraEventPayload = ExtraEventPayload(node=self.node, player=player, data=data)
+                    self.dispatch("extra_event", other_payload)
             else:
                 logger.debug(f"'Received an unknown OP from Lavalink '{data['op']}'. Disregarding.")
 


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

This adds an `on_wavelink_extra_event` dispatched event for all unhandled or unknown events received via Lavalink. This only happens when a Plugin sends an event as all base Lavalink events are currently handled.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [x] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
