### PR TITLE
Fix/autoplay queue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wavelink"
-version = "3.2.0"
+version = "3.2.1"
 authors = [
   { name="PythonistaGuild, EvieePy", email="evieepy@gmail.com" },
 ]

--- a/wavelink/__init__.py
+++ b/wavelink/__init__.py
@@ -25,7 +25,7 @@ __title__ = "WaveLink"
 __author__ = "PythonistaGuild, EvieePy"
 __license__ = "MIT"
 __copyright__ = "Copyright 2019-Present (c) PythonistaGuild, EvieePy"
-__version__ = "3.2.0"
+__version__ = "3.2.1"
 
 
 from .enums import *

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -375,6 +375,8 @@ class Player(discord.VoiceProtocol):
 
         if not self._current and self.auto_queue:
             now: Playable = self.auto_queue.get()
+            self.auto_queue.history.put(now)
+
             await self.play(now, add_history=False)
         else:
             logger.info(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -352,7 +352,7 @@ class Player(discord.VoiceProtocol):
         filtered_r: list[Playable] = [t for r in results for t in r]
 
         if not filtered_r and not self.auto_queue:
-            logger.debug(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
+            logger.info(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
             self._inactivity_start()
             return
 
@@ -373,9 +373,12 @@ class Player(discord.VoiceProtocol):
 
         logger.debug(f'Player "{self.guild.id}" added "{added}" tracks to the auto_queue via AutoPlay.')
 
-        if not self._current:
+        if not self._current and self.auto_queue:
             now: Playable = self.auto_queue.get()
             await self.play(now, add_history=False)
+        else:
+            logger.info(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
+            self._inactivity_start()
 
     @property
     def inactive_timeout(self) -> int | None:

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -373,14 +373,15 @@ class Player(discord.VoiceProtocol):
 
         logger.debug(f'Player "{self.guild.id}" added "{added}" tracks to the auto_queue via AutoPlay.')
 
-        if not self._current and self.auto_queue:
-            now: Playable = self.auto_queue.get()
-            self.auto_queue.history.put(now)
+        if not self._current:
+            try:
+                now: Playable = self.auto_queue.get()
+                self.auto_queue.history.put(now)
 
-            await self.play(now, add_history=False)
-        else:
-            logger.info(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
-            self._inactivity_start()
+                await self.play(now, add_history=False)
+            except wavelink.QueueEmpty:
+                logger.info(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
+                self._inactivity_start()
 
     @property
     def inactive_timeout(self) -> int | None:

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -351,17 +351,10 @@ class Player(discord.VoiceProtocol):
         # track for result in results for track in result...
         filtered_r: list[Playable] = [t for r in results for t in r]
 
-        if not filtered_r:
+        if not filtered_r and not self.auto_queue:
             logger.debug(f'Player "{self.guild.id}" could not load any songs via AutoPlay.')
             self._inactivity_start()
             return
-
-        if not self._current:
-            now: Playable = filtered_r.pop(1)
-            now._recommended = True
-            self.auto_queue.history.put(now)
-
-            await self.play(now, add_history=False)
 
         # Possibly adjust these thresholds?
         history: list[Playable] = (
@@ -369,6 +362,8 @@ class Player(discord.VoiceProtocol):
         )
 
         added: int = 0
+
+        random.shuffle(filtered_r)
         for track in filtered_r:
             if track in history:
                 continue
@@ -376,11 +371,11 @@ class Player(discord.VoiceProtocol):
             track._recommended = True
             added += await self.auto_queue.put_wait(track)
 
-        random.shuffle(self.auto_queue._items)
         logger.debug(f'Player "{self.guild.id}" added "{added}" tracks to the auto_queue via AutoPlay.')
 
-        # Probably don't need this here as it's likely to be cancelled instantly...
-        self._inactivity_start()
+        if not self._current:
+            now: Playable = self.auto_queue.get()
+            await self.play(now, add_history=False)
 
     @property
     def inactive_timeout(self) -> int | None:


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Fixes a logic error that would randomize the auto_queue everytime tracks were added instead of just randomizing the tracks that are added.

Fixes an issue where the player might not play the next track in auto_queue if it can't find new tracks (even when there are tracks in auto_queue).

Fixes an issue where the player plays the next track before the auto_queue has completed adding its tracks. Although this isn't really a bug it's probably a bad way of doing things as when systems rely on updates in track_start auto_queue could be outdated/incomplete.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
