### PR TITLE
Fix queue loop not repeating song after it's finished

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -787,6 +787,7 @@ class Player(discord.VoiceProtocol):
 
         old_previous = self._previous
         self._previous = self._current
+        self.queue._loaded = track
 
         pause: bool
         if paused is not None:
@@ -809,6 +810,7 @@ class Player(discord.VoiceProtocol):
         try:
             await self.node._update_player(self.guild.id, data=request, replace=replace)
         except LavalinkException as e:
+            self.queue._loaded = old_previous
             self._current = None
             self._original = None
             self._previous = old_previous


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Fix songs not repeating even though QueueMode.loop and AutoPlay.partial/AutoPlay.enabled are set.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
