### PR TITLE
Fix potential `get_wait` hang if queue only receives a list in `put_w…

### DIFF
--- a/wavelink/queue.py
+++ b/wavelink/queue.py
@@ -393,6 +393,7 @@ class Queue:
             if atomic:
                 self._check_atomic(item)
                 self._items.extend(item)
+                self._wakeup_next()
                 added = len(item)
             else:
 

--- a/wavelink/queue.py
+++ b/wavelink/queue.py
@@ -393,7 +393,6 @@ class Queue:
             if atomic:
                 self._check_atomic(item)
                 self._items.extend(item)
-                self._wakeup_next()
                 added = len(item)
             else:
 
@@ -444,6 +443,7 @@ class Queue:
                 if atomic:
                     self._check_atomic(item)
                     self._items.extend(item)
+                    self._wakeup_next()
                     return len(item)
 
                 for track in item:


### PR DESCRIPTION
## Description

`get_wait` would never have its waiter woken up if a list were to be passed in an atomic `put_wait` with no subsequent calls of another type as an early return overlooked `_wakeup_next`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
