### PR TITLE
Feature/playable node and Inactive Channel Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Github License](https://img.shields.io/github/license/PythonistaGuild/Wavelink)](LICENSE)
 [![Lavalink Version](https://img.shields.io/badge/Lavalink-v4.0%2B-blue?color=%23FB7713)](https://lavalink.dev)
 ![Lavalink Plugins](https://img.shields.io/badge/Lavalink_Plugins-Native_Support-blue?color=%2373D673)
-[![Discord](https://img.shields.io/discord/490948346773635102?logo=discord&logoColor=%23FFF&label=Pythonista&labelColor=%235865F2&color=%232B2D31)](https://discord.gg/RAKc3HF)
 
 
 </div>

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -901,7 +901,7 @@ class Pool:
         return sorted(nodes, key=lambda n: n._total_player_count or len(n.players))[0]
 
     @classmethod
-    async def fetch_tracks(cls, query: str, /) -> list[Playable] | Playlist:
+    async def fetch_tracks(cls, query: str, /, *, node: Node | None = None) -> list[Playable] | Playlist:
         """Search for a list of :class:`~wavelink.Playable` or a :class:`~wavelink.Playlist`, with the given query.
 
         Parameters
@@ -909,6 +909,9 @@ class Pool:
         query: str
             The query to search tracks for. If this is not a URL based search you should provide the appropriate search
             prefix, e.g. "ytsearch:Rick Roll"
+        node: :class:`~wavelink.Node` | None
+            An optional :class:`~wavelink.Node` to use when fetching tracks. Defaults to ``None``, which selects the
+            most appropriate :class:`~wavelink.Node` automatically.
 
         Returns
         -------
@@ -929,6 +932,11 @@ class Pool:
             or an empty list if no results were found.
 
             This method no longer accepts the ``cls`` parameter.
+
+
+        .. versionadded:: 3.4.0
+
+            Added the ``node`` Keyword-Only argument.
         """
 
         # TODO: Documentation Extension for `.. positional-only::` marker.
@@ -940,8 +948,8 @@ class Pool:
             if potential:
                 return potential
 
-        node: Node = cls.get_node()
-        resp: LoadedResponse = await node._fetch_tracks(encoded_query)
+        node_: Node = node or cls.get_node()
+        resp: LoadedResponse = await node_._fetch_tracks(encoded_query)
 
         if resp["loadType"] == "track":
             track = Playable(data=resp["data"])

--- a/wavelink/node.py
+++ b/wavelink/node.py
@@ -126,6 +126,9 @@ class Node:
     inactive_player_timeout: int | None
         Set the default for :attr:`wavelink.Player.inactive_timeout` on every player that connects to this node.
         Defaults to ``300``.
+    inactive_channel_tokens: int | None
+        Sets the default for :attr:`wavelink.Player.inactive_channel_tokens` on every player that connects to this node.
+        Defaults to ``3``.
 
         See also: :func:`on_wavelink_inactive_player`.
     """
@@ -142,6 +145,7 @@ class Node:
         client: discord.Client | None = None,
         resume_timeout: int = 60,
         inactive_player_timeout: int | None = 300,
+        inactive_channel_tokens: int | None = 3,
     ) -> None:
         self._identifier = identifier or secrets.token_urlsafe(12)
         self._uri = uri.removesuffix("/")
@@ -169,6 +173,8 @@ class Node:
         self._inactive_player_timeout = (
             inactive_player_timeout if inactive_player_timeout and inactive_player_timeout > 0 else None
         )
+
+        self._inactive_channel_tokens = inactive_channel_tokens
 
     def __repr__(self) -> str:
         return f"Node(identifier={self.identifier}, uri={self.uri}, status={self.status}, players={len(self.players)})"

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -370,7 +370,7 @@ class Player(discord.VoiceProtocol):
                 return []
 
             try:
-                search: wavelink.Search = await Pool.fetch_tracks(query)
+                search: wavelink.Search = await Pool.fetch_tracks(query, node=self._node)
             except (LavalinkLoadException, LavalinkException):
                 return []
 

--- a/wavelink/tracks.py
+++ b/wavelink/tracks.py
@@ -37,6 +37,7 @@ from .utils import ExtrasNamespace
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from .node import Node
     from .types.tracks import (
         PlaylistInfoPayload,
         PlaylistPayload,
@@ -323,7 +324,9 @@ class Playable:
         return self._raw_data
 
     @classmethod
-    async def search(cls, query: str, /, *, source: TrackSource | str | None = TrackSource.YouTubeMusic) -> Search:
+    async def search(
+        cls, query: str, /, *, source: TrackSource | str | None = TrackSource.YouTubeMusic, node: Node | None = None
+    ) -> Search:
         """Search for a list of :class:`~wavelink.Playable` or a :class:`~wavelink.Playlist`, with the given query.
 
         .. note::
@@ -355,6 +358,9 @@ class Playable:
             LavaSrc Spotify based search.
 
             Defaults to :attr:`wavelink.TrackSource.YouTubeMusic` which is equivalent to "ytmsearch:".
+        node: :class:`~wavelink.Node` | None
+            An optional :class:`~wavelink.Node` to use when searching for tracks. Defaults to ``None``, which uses
+            the :class:`~wavelink.Pool`'s automatic node selection.
 
 
         Returns
@@ -410,7 +416,7 @@ class Playable:
         check = yarl.URL(query)
 
         if check.host:
-            tracks: Search = await wavelink.Pool.fetch_tracks(query)
+            tracks: Search = await wavelink.Pool.fetch_tracks(query, node=node)
             return tracks
 
         if not prefix:
@@ -419,7 +425,7 @@ class Playable:
             assert not isinstance(prefix, TrackSource)
             term: str = f"{prefix.removesuffix(':')}:{query}"
 
-        tracks: Search = await wavelink.Pool.fetch_tracks(term)
+        tracks: Search = await wavelink.Pool.fetch_tracks(term, node=node)
         return tracks
 
 


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

Allows a `Node` to be passed to both `Playable.search` and `Pool.fetch_tracks` to search for the given query. If `None` is passed (Default) both of these methods act as they previously did.

This also adds:

Add the inactive_channel check to Player. The check dispatches the currently available wavelink_inactive_player event via Discord.py when a channel is deemed inactive.

An inactive channel is one where no real(non-bot) members are in the channel for a specified amount of played tracks. This differs from the current inactive_timeout which is a time based check on how long the player has not been playing, though they both work together.

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
