### PR TITLE
Updated player to default to track.position instead of 'start'

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -820,6 +820,7 @@ class Player(discord.VoiceProtocol):
         start: int
             The position to start playing the track at in milliseconds.
             Defaults to ``0`` which will start the track from the beginning.
+            If ``track.position`` has a non-zero position, that position will be used instead. 
         end: Optional[int]
             The position to end the track at in milliseconds.
             Defaults to ``None`` which means this track will play until the very end.
@@ -899,6 +900,9 @@ class Player(discord.VoiceProtocol):
 
         if filters:
             self._filters = filters
+
+        start = track.position or start
+        track._position = 0
 
         request: RequestPayload = {
             "track": {"encoded": track.encoded, "userData": dict(track.extras)},


### PR DESCRIPTION
## Description

When playing a track the `start` parameter worked as expected, but when adding a track to the queue there is not a `start` option. The best solution was to use the existing position variable inside of track as the default start position. 

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
