### PR TITLE
Fix voice session destroyed after bot moved

### DIFF
--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -178,18 +178,14 @@ class Player(discord.VoiceProtocol):
             return
 
         self._connected = False
-
-        # Wait for the reconnect event to be set.
         await self._reconnecting.wait()
-
-        # Verify the voice state to determine if a reconnect has occurred.
+        
         if self.guild and self.guild.me and self.guild.me.voice and self.guild.me.voice.channel:
-            # If the bot is connected to a new channel, mark as connected.
             self._connected = True
             self._connection_event.set()
             logger.debug("Reconnected during move; skipping _destroy() in _disconnected_wait.")
             return
-
+            
         if self._connected:
             return
 

--- a/wavelink/player.py
+++ b/wavelink/player.py
@@ -178,13 +178,23 @@ class Player(discord.VoiceProtocol):
             return
 
         self._connected = False
+
+        # Wait for the reconnect event to be set.
         await self._reconnecting.wait()
+
+        # Verify the voice state to determine if a reconnect has occurred.
+        if self.guild and self.guild.me and self.guild.me.voice and self.guild.me.voice.channel:
+            # If the bot is connected to a new channel, mark as connected.
+            self._connected = True
+            self._connection_event.set()
+            logger.debug("Reconnected during move; skipping _destroy() in _disconnected_wait.")
+            return
 
         if self._connected:
             return
 
         await self._destroy()
-
+        
     def _inactivity_task_callback(self, task: asyncio.Task[bool]) -> None:
         cancelled: bool = False
 


### PR DESCRIPTION
When the bot moves channels, the player was being destroyed because the disconnect wait did not account for the brief period between disconnect and reconnect. This commit modifies `_disconnected_wait` to wait for the `_reconnecting` event and then verifies the current voice state via `guild.me.voice.channel` If a valid channel is detected, the connection is restored without calling `_destroy()`  This prevents accidental player deletion during channel moves.

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

This PR fixes an issue where the player was inadvertently destroyed when the bot moved from one voice channel to another. By waiting for `_reconnecting` and checking `guild.me.voice.channel`, we ensure that a valid reconnect occurs before deciding whether to destroy the player. This prevents the brief disconnect period from prematurely removing the player's session during channel moves.

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
  - [ ] I have updated the changelog with a quick recap of my changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution